### PR TITLE
push/load/multi_deploy: correctly choose img tool for host

### DIFF
--- a/img/private/common/transitions.bzl
+++ b/img/private/common/transitions.bzl
@@ -72,15 +72,15 @@ normalize_layer_transition = transition(
     outputs = [_original_platforms_setting],
 )
 
-def _host_platform_transition_impl(settings, _attr):
+def _host_platform_transition_impl(_settings, _attr):
     return {
-        "//command_line_option:extra_execution_platforms": [str(platform) for platform in settings[_platforms_setting]],
+        "//command_line_option:platforms": [Label("@platforms//host")],
     }
 
 host_platform_transition = transition(
     implementation = _host_platform_transition_impl,
     inputs = [_platforms_setting],
     outputs = [
-        "//command_line_option:extra_execution_platforms",
+        "//command_line_option:platforms",
     ],
 )


### PR DESCRIPTION
The following use case was broken accidentally:

```
bazel run --platforms=//platforms:linux_arm64 //app:my_image
```

In this case, we want to build the image for the target platform (Linux, arm64) but still need to choose a push binary that can run on the host platform (macOS, Windows, different arch, ...).

The `host_platform_transition` was supposed to always transition to the host platform but didn't.