### PR TITLE
Add support for `--repo_contents_cache`

### DIFF
--- a/img/private/repository_rules/pull.bzl
+++ b/img/private/repository_rules/pull.bzl
@@ -246,6 +246,12 @@ alias(
             tag = repr(rctx.attr.tag) if rctx.attr.tag else "None",
         ),
     )
+    if len(rctx.attr.digest) > 0 and hasattr(rctx, "repo_metadata"):
+        # allows participating in repo contents cache
+        return rctx.repo_metadata(reproducible = True)
+
+    # only to make buildifier happy
+    return None
 
 pull = repository_rule(
     implementation = _pull_impl,

--- a/pull_tool/pull/private/pull_bootstrap.bzl
+++ b/pull_tool/pull/private/pull_bootstrap.bzl
@@ -45,6 +45,19 @@ def _pull_bootstrap_impl(rctx):
         """exports_files(["pull_tool.exe"])""",
     )
 
+    # cleanup symlinks
+    rctx.delete("go.mod")
+    rctx.delete("go.sum")
+    rctx.delete("cmd")
+    rctx.delete("pkg")
+
+    if hasattr(rctx, "repo_metadata"):
+        # allows participating in repo contents cache
+        return rctx.repo_metadata(reproducible = True)
+
+    # only to make buildifier happy
+    return None
+
 pull_bootstrap = repository_rule(
     implementation = _pull_bootstrap_impl,
     attrs = {


### PR DESCRIPTION
This allows `pull` and the bootstrapped pull_tool binary to be shared across workspaces and `bazel clean --expunge` invocations. Requires Bazel 8.3.0 and later.