### PR TITLE
cache: correlate requests with invocations

### DIFF
--- a/img_tool/cmd/bes/BUILD.bazel
+++ b/img_tool/cmd/bes/BUILD.bazel
@@ -17,10 +17,15 @@ go_library(
     ],
 )
 
+version_x_defs = {
+    "github.com/bazel-contrib/rules_img/img_tool/pkg/version.Version": module_version() or "dev",
+}
+
 go_binary(
     name = "bes",
     embed = [":bes_lib"],
     visibility = ["//visibility:public"],
+    x_defs = version_x_defs,
 )
 
 build_test(

--- a/img_tool/cmd/bes/bes.go
+++ b/img_tool/cmd/bes/bes.go
@@ -29,6 +29,7 @@ func Run(ctx context.Context, args []string) {
 	var commitMode string
 	var casEndpoint string
 	var credentialHelperPath string
+	var toolInvocationID string
 
 	flagSet := flag.NewFlagSet("bes", flag.ExitOnError)
 	flagSet.Usage = func() {
@@ -51,6 +52,8 @@ func Run(ctx context.Context, args []string) {
 	flagSet.StringVar(&commitMode, "commit-mode", "background", "Commit mode: 'background' or 'per-stream'")
 	flagSet.StringVar(&casEndpoint, "cas-endpoint", "", "CAS gRPC endpoint (required)")
 	flagSet.StringVar(&credentialHelperPath, "credential-helper", "", "Path to credential helper binary (optional, defaults to no helper)")
+	flagSet.StringVar(&toolInvocationID, "invocation-id", "", "REAPI RequestMetadata tool invocation ID")
+	flagSet.StringVar(&toolInvocationID, "invocation_id", "", "Alias for --invocation-id")
 
 	if err := flagSet.Parse(args[1:]); err != nil {
 		fmt.Fprint(os.Stderr, err.Error())
@@ -85,7 +88,20 @@ func Run(ctx context.Context, args []string) {
 		log.Println("No credential helper configured")
 	}
 
-	grpcClientConn, err := protohelper.Client(casEndpoint, credentialHelper)
+	requestMetadata, _ := protohelper.RequestMetadataFromContext(ctx)
+	if toolInvocationID != "" {
+		requestMetadata.ToolInvocationID = toolInvocationID
+	}
+	if requestMetadata.ActionID == "" {
+		requestMetadata.ActionID = "rules_img:bes"
+	}
+	if requestMetadata.ActionMnemonic == "" {
+		requestMetadata.ActionMnemonic = "ImgBESCommit"
+	}
+	if requestMetadata.TargetID == "" {
+		requestMetadata.TargetID = "rules_img"
+	}
+	grpcClientConn, err := protohelper.ClientWithRequestMetadata(casEndpoint, credentialHelper, requestMetadata)
 	if err != nil {
 		log.Fatalf("Failed to create gRPC client connection to CAS: %v", err)
 	}

--- a/img_tool/cmd/deploy/BUILD.bazel
+++ b/img_tool/cmd/deploy/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "dedup_locations_test.go",
         "dedup_push_test.go",
         "dedup_registry_test.go",
+        "persistentworker_test.go",
         "progress_test.go",
         "sign_sink_test.go",
         "sink_test.go",

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -65,7 +65,7 @@ func DeployProcess(ctx context.Context, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		if err := persistentWorker(jobs, sinkSpec, dedupFlags{
+		if err := persistentWorker(ctx, jobs, sinkSpec, dedupFlags{
 			mode:           extractFlag(processedArgs, "--deduplicated-push"),
 			blobRepository: extractFlag(processedArgs, "--deduplicated-push-blob-repository"),
 			content:        extractFlag(processedArgs, "--deduplicated-push-content"),
@@ -155,6 +155,7 @@ func DeployProcess(ctx context.Context, args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	ctx = withDeployRequestMetadata(ctx, requestFiles)
 
 	opts := DeployOptions{
 		AdditionalTags:             []string(additionalTags),
@@ -181,6 +182,19 @@ func DeployProcess(ctx context.Context, args []string) {
 		fmt.Fprintf(os.Stderr, "Error during deploy: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func withDeployRequestMetadata(ctx context.Context, requestFiles []string) context.Context {
+	requestMetadata, _ := protohelper.RequestMetadataFromContext(ctx)
+	requestMetadata.ActionMnemonic = "ImgDeploy"
+	requestMetadata.ActionID = "rules_img:deploy"
+	requestMetadata.TargetID = "rules_img"
+	if len(requestFiles) > 0 {
+		logicalRequest := strings.Join(requestFiles, ",")
+		requestMetadata.ActionID += ":" + logicalRequest
+		requestMetadata.TargetID = logicalRequest
+	}
+	return protohelper.WithRequestMetadata(ctx, requestMetadata)
 }
 
 // mergeRequestFiles reads multiple deploy manifest files and merges them into a single manifest.
@@ -323,7 +337,7 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 			break
 		}
 	}
-	vfsBuilder, casBlobs, err := configureBuilderFromEnv(vfsBuilder, hasLazyStrategy, opts.Jobs)
+	vfsBuilder, casBlobs, err := configureBuilderFromEnv(ctx, vfsBuilder, hasLazyStrategy, opts.Jobs)
 	if err != nil {
 		return err
 	}
@@ -796,7 +810,7 @@ func credentialHelperInstance() credential.Helper {
 // CAS reads go through a local blob cache (see casBlobCacheFromEnv). Both it and
 // the connection pool behind it are returned so the caller can report their
 // statistics and close them; the result is nil when no CAS is configured.
-func configureBuilderFromEnv(builder *deployvfs.Builder, needsCAS bool, jobs int) (*deployvfs.Builder, *casSources, error) {
+func configureBuilderFromEnv(ctx context.Context, builder *deployvfs.Builder, needsCAS bool, jobs int) (*deployvfs.Builder, *casSources, error) {
 	diskCachePath := os.Getenv("IMG_DISK_CACHE")
 	if diskCachePath != "" {
 		builder = builder.WithDiskCache(diskCachePath)
@@ -818,8 +832,9 @@ func configureBuilderFromEnv(builder *deployvfs.Builder, needsCAS bool, jobs int
 	// reads across them (cf. Bazel's --remote_max_connections).
 	numConns := reapiMaxConnections(jobs)
 	members := make([]*cas.CAS, 0, numConns)
+	requestMetadata, _ := protohelper.RequestMetadataFromContext(ctx)
 	for range numConns {
-		grpcConn, err := protohelper.Client(reapiEndpoint, credHelper)
+		grpcConn, err := protohelper.ClientWithRequestMetadata(reapiEndpoint, credHelper, requestMetadata)
 		if err != nil {
 			return nil, nil, fmt.Errorf("creating gRPC client for REAPI: %w", err)
 		}

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/deployvfs"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/gateway"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/load"
@@ -29,6 +30,10 @@ type deployWorkerHandler struct {
 	jobs          int
 	baseBuilder   *deployvfs.Builder
 	pushTransport http.RoundTripper
+	// requestMetadata is inherited from the worker startup context. Bazel does
+	// not include BUILD_ID in WorkRequest, so this preserves a global
+	// --invocation-id / BUILD_ID while allowing a per-request flag to override it.
+	requestMetadata protohelper.RequestMetadata
 
 	// casBlobs is the connection pool to the remote CAS and the blob cache in
 	// front of it, which lives for the lifetime of the worker so requests that
@@ -54,7 +59,7 @@ type deployWorkerHandler struct {
 	sinkMu     sync.Mutex
 }
 
-func newDeployWorkerHandler(jobs int, sinkSpec string, deduplicatedPush dedupFlags) (*deployWorkerHandler, error) {
+func newDeployWorkerHandler(ctx context.Context, jobs int, sinkSpec string, deduplicatedPush dedupFlags) (*deployWorkerHandler, error) {
 	if err := validateDeduplicatedPushOverride(deduplicatedPush.mode); err != nil {
 		return nil, err
 	}
@@ -84,7 +89,7 @@ func newDeployWorkerHandler(jobs int, sinkSpec string, deduplicatedPush dedupFla
 	// We set needsCAS to true unconditionally.
 	// The reason is that we just cannot know in advance whether a future work request
 	// wants to connect to the remote cache or not.
-	baseBuilder, casBlobs, err := configureBuilderFromEnv(baseBuilder, true /* needsCAS */, jobs)
+	baseBuilder, casBlobs, err := configureBuilderFromEnv(ctx, baseBuilder, true /* needsCAS */, jobs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to configure VFS from environment: %v\n", err)
 	}
@@ -99,6 +104,7 @@ func newDeployWorkerHandler(jobs int, sinkSpec string, deduplicatedPush dedupFla
 		// request needs it and published for the rest.
 		blobLocations: newBlobLocations(true),
 	}
+	h.requestMetadata, _ = protohelper.RequestMetadataFromContext(ctx)
 
 	if sinkSpec != "" {
 		// A global distribution/oci sink redirects every request; no pusher is
@@ -151,6 +157,7 @@ func (h *deployWorkerHandler) processRequest(ctx context.Context, req persistent
 	if err != nil {
 		return "", fmt.Errorf("parsing arguments: %w", err)
 	}
+	ctx = withWorkerRequestMetadata(ctx, h.requestMetadata, opts.requestFiles, opts.toolInvocationID)
 
 	rawRequest, err := mergeRequestFiles(opts.requestFiles)
 	if err != nil {
@@ -482,6 +489,7 @@ type workerOpts struct {
 	overrideRepository string
 	platforms          []string
 	sink               string
+	toolInvocationID   string
 	// deduplicatedPush holds this work request's overrides of the deduplicated push
 	// settings recorded per operation in its deploy manifest.
 	deduplicatedPush dedupFlags
@@ -610,6 +618,18 @@ func parseWorkerArgs(args []string) (*workerOpts, error) {
 				return nil, err
 			}
 			opts.deduplicatedPush.content = value
+		case key == "--invocation-id" || key == "--invocation_id":
+			if !hasValue {
+				if i+1 >= len(args) {
+					return nil, fmt.Errorf("%s requires a value", key)
+				}
+				i++
+				value = args[i]
+			}
+			if value == "" {
+				return nil, fmt.Errorf("%s requires a value", key)
+			}
+			opts.toolInvocationID = value
 		case key == "--insecure":
 			// The worker builds its transports and pusher once, at startup, so
 			// insecure mode cannot be turned on per work request. Reject it
@@ -627,8 +647,17 @@ func parseWorkerArgs(args []string) (*workerOpts, error) {
 	return opts, nil
 }
 
-func persistentWorker(jobs int, sinkSpec string, deduplicatedPush dedupFlags) error {
-	handler, err := newDeployWorkerHandler(jobs, sinkSpec, deduplicatedPush)
+func withWorkerRequestMetadata(ctx context.Context, defaults protohelper.RequestMetadata, requestFiles []string, toolInvocationID string) context.Context {
+	ctx = protohelper.WithRequestMetadata(ctx, defaults)
+	ctx = withDeployRequestMetadata(ctx, requestFiles)
+	if toolInvocationID != "" {
+		ctx = protohelper.WithToolInvocationID(ctx, toolInvocationID)
+	}
+	return ctx
+}
+
+func persistentWorker(ctx context.Context, jobs int, sinkSpec string, deduplicatedPush dedupFlags) error {
+	handler, err := newDeployWorkerHandler(ctx, jobs, sinkSpec, deduplicatedPush)
 	if err != nil {
 		return err
 	}

--- a/img_tool/cmd/deploy/persistentworker_test.go
+++ b/img_tool/cmd/deploy/persistentworker_test.go
@@ -1,0 +1,81 @@
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
+)
+
+func TestParseWorkerArgsInvocationID(t *testing.T) {
+	for _, args := range [][]string{
+		{"--request-file", "request.json", "--invocation-id", "1234"},
+		{"--request-file=request.json", "--invocation_id=1234"},
+	} {
+		opts, err := parseWorkerArgs(args)
+		if err != nil {
+			t.Fatalf("parseWorkerArgs(%v): %v", args, err)
+		}
+		if opts.toolInvocationID != "1234" {
+			t.Errorf("parseWorkerArgs(%v) invocation ID = %q, want 1234", args, opts.toolInvocationID)
+		}
+	}
+}
+
+func TestDeployRequestMetadataUsesLogicalRequest(t *testing.T) {
+	ctx := protohelper.WithToolInvocationID(context.Background(), "invocation")
+	ctx = withDeployRequestMetadata(ctx, []string{"bazel-out/bin/images/app.deploy.json"})
+	got, ok := protohelper.RequestMetadataFromContext(ctx)
+	if !ok {
+		t.Fatal("request metadata is missing")
+	}
+	if got.ToolInvocationID != "invocation" {
+		t.Errorf("tool invocation ID = %q, want invocation", got.ToolInvocationID)
+	}
+	if got.ActionMnemonic != "ImgDeploy" || got.TargetID != "bazel-out/bin/images/app.deploy.json" || got.ActionID != "rules_img:deploy:bazel-out/bin/images/app.deploy.json" {
+		t.Errorf("logical deploy metadata = %+v", got)
+	}
+}
+
+func TestWorkerRequestMetadataInheritsStartupInvocation(t *testing.T) {
+	defaults := protohelper.RequestMetadata{
+		ToolInvocationID: "startup-invocation",
+		ActionID:         "rules_img:deploy",
+		ActionMnemonic:   "ImgDeploy",
+		TargetID:         "rules_img",
+	}
+	ctx := withWorkerRequestMetadata(context.Background(), defaults, []string{"app.deploy.json"}, "")
+	got, ok := protohelper.RequestMetadataFromContext(ctx)
+	if !ok {
+		t.Fatal("request metadata is missing")
+	}
+	if got.ToolInvocationID != "startup-invocation" {
+		t.Errorf("tool invocation ID = %q, want startup-invocation", got.ToolInvocationID)
+	}
+	if got.ActionID != "rules_img:deploy:app.deploy.json" || got.TargetID != "app.deploy.json" {
+		t.Errorf("logical deploy metadata = %+v", got)
+	}
+}
+
+func TestWorkerRequestMetadataOverridesStartupInvocation(t *testing.T) {
+	defaults := protohelper.RequestMetadata{ToolInvocationID: "startup-invocation"}
+	ctx := withWorkerRequestMetadata(context.Background(), defaults, []string{"app.deploy.json"}, "request-invocation")
+	got, ok := protohelper.RequestMetadataFromContext(ctx)
+	if !ok {
+		t.Fatal("request metadata is missing")
+	}
+	if got.ToolInvocationID != "request-invocation" {
+		t.Errorf("tool invocation ID = %q, want request-invocation", got.ToolInvocationID)
+	}
+}
+
+func TestParseWorkerArgsRejectsMissingInvocationID(t *testing.T) {
+	for _, args := range [][]string{
+		{"--request-file=request.json", "--invocation-id"},
+		{"--request-file=request.json", "--invocation-id="},
+	} {
+		if _, err := parseWorkerArgs(args); err == nil {
+			t.Fatalf("expected %v to fail", args)
+		}
+	}
+}

--- a/img_tool/cmd/img/BUILD.bazel
+++ b/img_tool/cmd/img/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//cmd/sparseocilayout",
         "//cmd/syncocirefgraph",
         "//cmd/validate",
+        "//pkg/auth/protohelper",
         "//pkg/registryopts",
         "@com_github_google_go_containerregistry//pkg/logs",
     ],
@@ -83,5 +84,8 @@ go_test(
     name = "img_test",
     srcs = ["img_test.go"],
     embed = [":img_lib"],
-    deps = ["//pkg/registryopts"],
+    deps = [
+        "//pkg/auth/protohelper",
+        "//pkg/registryopts",
+    ],
 )

--- a/img_tool/cmd/img/img.go
+++ b/img_tool/cmd/img/img.go
@@ -223,17 +223,18 @@ func handleGlobalFlags(args []string) ([]string, globalOptions, error) {
 			opts.toolInvocationID = args[i]
 			continue
 		}
+		consumed := false
 		for _, prefix := range []string{"--invocation-id=", "-invocation-id=", "--invocation_id=", "-invocation_id="} {
 			if value, ok := strings.CutPrefix(arg, prefix); ok {
 				if value == "" {
 					return nil, globalOptions{}, fmt.Errorf("%s requires a value", strings.TrimSuffix(arg, "="))
 				}
 				opts.toolInvocationID = value
-				arg = ""
+				consumed = true
 				break
 			}
 		}
-		if arg == "" {
+		if consumed {
 			continue
 		}
 		filtered = append(filtered, arg)

--- a/img_tool/cmd/img/img.go
+++ b/img_tool/cmd/img/img.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/logs"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/bazel-contrib/rules_img/img_tool/cmd/sparseocilayout"
 	"github.com/bazel-contrib/rules_img/img_tool/cmd/syncocirefgraph"
 	"github.com/bazel-contrib/rules_img/img_tool/cmd/validate"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/registryopts"
 )
 
@@ -44,6 +46,8 @@ Global flags (accepted by any command):
   --insecure               allows registries to be addressed over plain HTTP and
                            accepts untrusted TLS certificates (like crane's
                            --insecure). Also settable via IMG_INSECURE=1.
+  --invocation-id ID       sets RequestMetadata.tool_invocation_id on outgoing
+                           REAPI and ByteStream requests
 
 Commands:
   base                     describes base image contents (subcommands: etc, trust-store, system-libraries, skeleton)
@@ -80,7 +84,22 @@ func Run(ctx context.Context, args []string) {
 	// Handle the global flags for all subcommands. We strip them from
 	// the arguments before dispatching so each subcommand's own flag parser
 	// doesn't have to know about them.
-	args = handleGlobalFlags(args)
+	args, globalOpts, err := handleGlobalFlags(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		fmt.Fprintln(os.Stderr, usage)
+		os.Exit(1)
+	}
+	toolInvocationID := resolveToolInvocationID(globalOpts)
+	if len(args) >= 2 {
+		command := args[1]
+		ctx = protohelper.WithRequestMetadata(ctx, protohelper.RequestMetadata{
+			ToolInvocationID: toolInvocationID,
+			ActionID:         "rules_img:" + command,
+			ActionMnemonic:   actionMnemonic(command),
+			TargetID:         "rules_img",
+		})
+	}
 
 	if len(args) < 2 {
 		fmt.Fprintln(os.Stderr, usage)
@@ -153,12 +172,26 @@ func Run(ctx context.Context, args []string) {
 	}
 }
 
+func resolveToolInvocationID(opts globalOptions) string {
+	if opts.toolInvocationID != "" {
+		return opts.toolInvocationID
+	}
+	// Bazel sets BUILD_ID to the command's invocation UUID for `bazel run`.
+	// Explicit --invocation-id always wins, while this fallback makes generated
+	// image_push/image_load launchers correlate without extra user wiring.
+	return os.Getenv("BUILD_ID")
+}
+
 func main() {
 	ctx := context.Background()
 	Run(ctx, os.Args)
 }
 
-// handleGlobalFlags looks for the global flags (--verbose, --insecure) anywhere
+type globalOptions struct {
+	toolInvocationID string
+}
+
+// handleGlobalFlags looks for global flags anywhere
 // in args, applies them, and returns args with those flags removed so the
 // individual subcommand flag parsers don't see them.
 //
@@ -166,17 +199,41 @@ func main() {
 //   - --insecure lets every registry operation talk plain HTTP and accept
 //     untrusted TLS certificates, like crane's --insecure. It is only ever
 //     enabling: without the flag, IMG_INSECURE still decides.
-func handleGlobalFlags(args []string) []string {
+//   - --invocation-id sets RequestMetadata.tool_invocation_id on outgoing
+//     REAPI and ByteStream requests.
+func handleGlobalFlags(args []string) ([]string, globalOptions, error) {
 	filtered := make([]string, 0, len(args))
+	var opts globalOptions
 	verbose := false
 	insecure := false
-	for _, arg := range args {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		switch arg {
 		case "--verbose", "-verbose":
 			verbose = true
 			continue
 		case "--insecure", "-insecure":
 			insecure = true
+			continue
+		case "--invocation-id", "-invocation-id", "--invocation_id", "-invocation_id":
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				return nil, globalOptions{}, fmt.Errorf("%s requires a value", arg)
+			}
+			i++
+			opts.toolInvocationID = args[i]
+			continue
+		}
+		for _, prefix := range []string{"--invocation-id=", "-invocation-id=", "--invocation_id=", "-invocation_id="} {
+			if value, ok := strings.CutPrefix(arg, prefix); ok {
+				if value == "" {
+					return nil, globalOptions{}, fmt.Errorf("%s requires a value", strings.TrimSuffix(arg, "="))
+				}
+				opts.toolInvocationID = value
+				arg = ""
+				break
+			}
+		}
+		if arg == "" {
 			continue
 		}
 		filtered = append(filtered, arg)
@@ -187,5 +244,26 @@ func handleGlobalFlags(args []string) []string {
 	if insecure {
 		registryopts.SetInsecure(true)
 	}
-	return filtered
+	return filtered, opts, nil
+}
+
+func actionMnemonic(command string) string {
+	if command == "bes" {
+		return "ImgBES"
+	}
+	var mnemonic strings.Builder
+	mnemonic.WriteString("Img")
+	upperNext := true
+	for _, r := range command {
+		if r == '-' || r == '_' {
+			upperNext = true
+			continue
+		}
+		if upperNext {
+			r = []rune(strings.ToUpper(string(r)))[0]
+			upperNext = false
+		}
+		mnemonic.WriteRune(r)
+	}
+	return mnemonic.String()
 }

--- a/img_tool/cmd/img/img_test.go
+++ b/img_tool/cmd/img/img_test.go
@@ -12,10 +12,11 @@ import (
 // process into insecure-registry mode.
 func TestHandleGlobalFlags(t *testing.T) {
 	tests := []struct {
-		name         string
-		args         []string
-		wantArgs     []string
-		wantInsecure bool
+		name             string
+		args             []string
+		wantArgs         []string
+		wantInsecure     bool
+		wantInvocationID string
 	}{
 		{
 			name:     "no global flags",
@@ -40,6 +41,18 @@ func TestHandleGlobalFlags(t *testing.T) {
 			wantArgs:     []string{"img", "push", "blob"},
 			wantInsecure: true,
 		},
+		{
+			name:             "invocation ID after subcommand",
+			args:             []string{"img", "deploy", "--request-file", "req.json", "--invocation-id=1234"},
+			wantArgs:         []string{"img", "deploy", "--request-file", "req.json"},
+			wantInvocationID: "1234",
+		},
+		{
+			name:             "Bazel-style invocation ID spelling",
+			args:             []string{"img", "--invocation_id", "5678", "deploy", "--request-file", "req.json"},
+			wantArgs:         []string{"img", "deploy", "--request-file", "req.json"},
+			wantInvocationID: "5678",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -47,12 +60,18 @@ func TestHandleGlobalFlags(t *testing.T) {
 			registryopts.SetInsecure(false)
 			t.Cleanup(func() { registryopts.SetInsecure(previous) })
 
-			got := handleGlobalFlags(tc.args)
+			got, opts, err := handleGlobalFlags(tc.args)
+			if err != nil {
+				t.Fatalf("handleGlobalFlags(%v): %v", tc.args, err)
+			}
 			if !slices.Equal(got, tc.wantArgs) {
 				t.Errorf("handleGlobalFlags(%v) = %v, want %v", tc.args, got, tc.wantArgs)
 			}
 			if registryopts.Insecure() != tc.wantInsecure {
 				t.Errorf("insecure mode = %v, want %v", registryopts.Insecure(), tc.wantInsecure)
+			}
+			if opts.toolInvocationID != tc.wantInvocationID {
+				t.Errorf("tool invocation ID = %q, want %q", opts.toolInvocationID, tc.wantInvocationID)
 			}
 		})
 	}
@@ -65,8 +84,43 @@ func TestHandleGlobalFlagsKeepsEnvInsecure(t *testing.T) {
 	registryopts.SetInsecure(true)
 	t.Cleanup(func() { registryopts.SetInsecure(previous) })
 
-	handleGlobalFlags([]string{"img", "deploy", "--request-file", "req.json"})
+	if _, _, err := handleGlobalFlags([]string{"img", "deploy", "--request-file", "req.json"}); err != nil {
+		t.Fatal(err)
+	}
 	if !registryopts.Insecure() {
 		t.Error("insecure mode was disabled by args that don't mention --insecure")
+	}
+}
+
+func TestHandleGlobalFlagsRejectsMissingInvocationID(t *testing.T) {
+	for _, args := range [][]string{
+		{"img", "deploy", "--invocation-id"},
+		{"img", "deploy", "--invocation-id="},
+	} {
+		if _, _, err := handleGlobalFlags(args); err == nil {
+			t.Fatalf("expected %v to fail", args)
+		}
+	}
+}
+
+func TestActionMnemonic(t *testing.T) {
+	for command, want := range map[string]string{
+		"deploy":            "ImgDeploy",
+		"download-manifest": "ImgDownloadManifest",
+		"bes":               "ImgBES",
+	} {
+		if got := actionMnemonic(command); got != want {
+			t.Errorf("actionMnemonic(%q) = %q, want %q", command, got, want)
+		}
+	}
+}
+
+func TestResolveToolInvocationID(t *testing.T) {
+	t.Setenv("BUILD_ID", "bazel-invocation")
+	if got := resolveToolInvocationID(globalOptions{}); got != "bazel-invocation" {
+		t.Errorf("BUILD_ID fallback = %q, want bazel-invocation", got)
+	}
+	if got := resolveToolInvocationID(globalOptions{toolInvocationID: "explicit"}); got != "explicit" {
+		t.Errorf("explicit invocation ID = %q, want explicit", got)
 	}
 }

--- a/img_tool/cmd/img/img_test.go
+++ b/img_tool/cmd/img/img_test.go
@@ -53,6 +53,15 @@ func TestHandleGlobalFlags(t *testing.T) {
 			wantArgs:         []string{"img", "deploy", "--request-file", "req.json"},
 			wantInvocationID: "5678",
 		},
+		{
+			// image_push passes --original-tag "" for a base pinned by digest.
+			// Dropping the empty value would make --original-tag swallow the
+			// next flag and shift every argument after it, leaving the
+			// subcommand without its positional output path.
+			name:     "empty argument is passed through",
+			args:     []string{"img", "deploy-metadata", "--original-tag", "", "--original-digest", "sha256:abc", "push.json"},
+			wantArgs: []string{"img", "deploy-metadata", "--original-tag", "", "--original-digest", "sha256:abc", "push.json"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/img_tool/cmd/registry/BUILD.bazel
+++ b/img_tool/cmd/registry/BUILD.bazel
@@ -25,11 +25,16 @@ go_library(
     ],
 )
 
+version_x_defs = {
+    "github.com/bazel-contrib/rules_img/img_tool/pkg/version.Version": module_version() or "dev",
+}
+
 go_binary(
     name = "registry",
     embed = [":registry_lib"],
     pure = "on",
     visibility = ["//visibility:public"],
+    x_defs = version_x_defs,
 )
 
 go_test(

--- a/img_tool/cmd/registry/registry.go
+++ b/img_tool/cmd/registry/registry.go
@@ -40,6 +40,7 @@ func Run(ctx context.Context, args []string) {
 	var s3Region string
 	var s3profile string
 	var credentialHelperPath string
+	var toolInvocationID string
 	var manifestTTL time.Duration
 	var tagTTLFlag optionalDuration
 	var casKeepAlive bool
@@ -75,6 +76,8 @@ func Run(ctx context.Context, args []string) {
 	flagSet.StringVar(&s3Region, "s3-region", "", "S3 region to use for the S3 blob store (optional, defaults to auto detect)")
 	flagSet.StringVar(&s3profile, "s3-profile", "", "AWS profile to use for the S3 blob store (optional, defaults to default profile)")
 	flagSet.StringVar(&credentialHelperPath, "credential-helper", "", "Path to credential helper binary (optional, defaults to no helper)")
+	flagSet.StringVar(&toolInvocationID, "invocation-id", "", "REAPI RequestMetadata tool invocation ID")
+	flagSet.StringVar(&toolInvocationID, "invocation_id", "", "Alias for --invocation-id")
 	flagSet.DurationVar(&manifestTTL, "ttl", 0, "How long a manifest or blob is kept after it was last pushed or pulled. Anything a tag or an unexpired index still references is kept regardless of its own age. 0 keeps everything until the process exits.")
 	flagSet.Var(&tagTTLFlag, "tag-ttl", "How long a tag is kept after it was last pushed or read. Defaults to --ttl, since a tag keeps everything it references alive. Set 0 to keep tags -- and their images -- forever.")
 	flagSet.BoolVar(&casKeepAlive, "cas-keepalive", false, `Periodically ask the remote cache about live blobs so it keeps them. Requires the "reapi" blob store.`)
@@ -110,7 +113,20 @@ func Run(ctx context.Context, args []string) {
 	var grpcClientConn *grpc.ClientConn
 	if reapiEndpoint != "" {
 		var err error
-		grpcClientConn, err = protohelper.Client(reapiEndpoint, credentialHelper)
+		requestMetadata, _ := protohelper.RequestMetadataFromContext(ctx)
+		if toolInvocationID != "" {
+			requestMetadata.ToolInvocationID = toolInvocationID
+		}
+		if requestMetadata.ActionID == "" {
+			requestMetadata.ActionID = "rules_img:registry"
+		}
+		if requestMetadata.ActionMnemonic == "" {
+			requestMetadata.ActionMnemonic = "ImgRegistry"
+		}
+		if requestMetadata.TargetID == "" {
+			requestMetadata.TargetID = "rules_img"
+		}
+		grpcClientConn, err = protohelper.ClientWithRequestMetadata(reapiEndpoint, credentialHelper, requestMetadata)
 		if err != nil {
 			log.Fatalf("Failed to create gRPC client connection: %v", err)
 		}

--- a/img_tool/pkg/auth/grpcheaderinterceptor/BUILD.bazel
+++ b/img_tool/pkg/auth/grpcheaderinterceptor/BUILD.bazel
@@ -1,5 +1,15 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
+# The test target is maintained by hand, and its source is hidden from gazelle,
+# so that it can keep a name far shorter than the one the naming convention
+# would give it ("grpcheaderinterceptor_test"). Windows caps a path at 260
+# characters, and a go_test's executable appears inside its own runfiles tree,
+# so the package and target name are each spelled twice: the conventional name
+# lands at 290 characters and the test cannot start at all ("cannot shorten the
+# path enough"). Keep this name short. Add any new test dependency to deps
+# below by hand — gazelle will not do it for you.
+# gazelle:exclude grpcheaderinterceptor_test.go
+
 go_library(
     name = "grpcheaderinterceptor",
     srcs = ["grpcheaderinterceptor.go"],
@@ -16,10 +26,12 @@ go_library(
 )
 
 go_test(
-    name = "grpcheaderinterceptor_test",
+    name = "main_test",
     size = "small",
+    # keep
     srcs = ["grpcheaderinterceptor_test.go"],
     embed = [":grpcheaderinterceptor"],
+    # keep
     deps = [
         "//pkg/auth/credential",
         "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",

--- a/img_tool/pkg/auth/grpcheaderinterceptor/BUILD.bazel
+++ b/img_tool/pkg/auth/grpcheaderinterceptor/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "grpcheaderinterceptor",
@@ -10,6 +10,21 @@ go_library(
         "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",
         "//pkg/version",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "grpcheaderinterceptor_test",
+    size = "small",
+    srcs = ["grpcheaderinterceptor_test.go"],
+    embed = [":grpcheaderinterceptor"],
+    deps = [
+        "//pkg/auth/credential",
+        "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//proto",
     ],

--- a/img_tool/pkg/auth/grpcheaderinterceptor/grpcheaderinterceptor.go
+++ b/img_tool/pkg/auth/grpcheaderinterceptor/grpcheaderinterceptor.go
@@ -21,25 +21,126 @@ import (
 // https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto
 const requestMetadataHeaderKey = "build.bazel.remote.execution.v2.requestmetadata-bin"
 
-// requestMetadataBin is the wire-encoded RequestMetadata identifying rules_img
-// as the calling tool, attached to every outgoing REAPI/CAS/ByteStream call.
-var requestMetadataBin = mustMarshalRequestMetadata()
+type requestMetadataContextKey struct{}
 
-func mustMarshalRequestMetadata() string {
-	b, err := proto.Marshal(&remoteexecution_proto.RequestMetadata{
-		ToolDetails: &remoteexecution_proto.ToolDetails{
-			ToolName:    "rules_img",
-			ToolVersion: version.Version,
-		},
-	})
+// RequestMetadata describes the rules_img-owned portion of REAPI request
+// metadata. Fields not represented here (for example correlated_invocations_id
+// and configuration_id) are preserved when callers already supplied metadata.
+type RequestMetadata struct {
+	ToolInvocationID string
+	ActionID         string
+	ActionMnemonic   string
+	TargetID         string
+}
+
+// WithRequestMetadata returns a context carrying metadata for one logical image
+// operation. The interceptor merges it with metadata already on the outgoing
+// context and emits exactly one RequestMetadata header.
+func WithRequestMetadata(ctx context.Context, requestMetadata RequestMetadata) context.Context {
+	return context.WithValue(ctx, requestMetadataContextKey{}, requestMetadata)
+}
+
+// WithToolInvocationID returns a context whose outgoing REAPI requests identify
+// the tool invocation that caused them. The context value overrides the default
+// configured on the client connection, which allows persistent workers to use a
+// different invocation ID for each work request.
+func WithToolInvocationID(ctx context.Context, toolInvocationID string) context.Context {
+	requestMetadata, _ := RequestMetadataFromContext(ctx)
+	requestMetadata.ToolInvocationID = toolInvocationID
+	return WithRequestMetadata(ctx, requestMetadata)
+}
+
+// RequestMetadataFromContext returns rules_img metadata stored on ctx.
+func RequestMetadataFromContext(ctx context.Context) (RequestMetadata, bool) {
+	requestMetadata, ok := ctx.Value(requestMetadataContextKey{}).(RequestMetadata)
+	return requestMetadata, ok
+}
+
+func marshalRequestMetadata(requestMetadata *remoteexecution_proto.RequestMetadata) string {
+	b, err := proto.Marshal(requestMetadata)
 	if err != nil {
 		panic(fmt.Sprintf("failed to marshal RequestMetadata: %v", err))
 	}
 	return string(b)
 }
 
+func mergeRequestMetadata(caller *remoteexecution_proto.RequestMetadata, rulesImg RequestMetadata) *remoteexecution_proto.RequestMetadata {
+	merged := &remoteexecution_proto.RequestMetadata{}
+	if caller != nil {
+		merged = proto.Clone(caller).(*remoteexecution_proto.RequestMetadata)
+	}
+
+	// The client making these RPCs is rules_img. This field is intentionally
+	// truthful; BuildBuddy attribution does not require tool_name="bazel".
+	merged.ToolDetails = &remoteexecution_proto.ToolDetails{
+		ToolName:    "rules_img",
+		ToolVersion: version.Version,
+	}
+	if rulesImg.ToolInvocationID != "" {
+		merged.ToolInvocationId = rulesImg.ToolInvocationID
+	}
+	// Caller-supplied logical action metadata is more specific than our
+	// defaults, so only fill fields that are absent.
+	if merged.ActionId == "" {
+		merged.ActionId = rulesImg.ActionID
+	}
+	if merged.ActionMnemonic == "" {
+		merged.ActionMnemonic = rulesImg.ActionMnemonic
+	}
+	if merged.TargetId == "" {
+		merged.TargetId = rulesImg.TargetID
+	}
+	return merged
+}
+
 type authenticatingInterceptor struct {
-	helper credential.Helper
+	helper                 credential.Helper
+	defaultRequestMetadata RequestMetadata
+}
+
+func (i *authenticatingInterceptor) requestMetadataBin(ctx context.Context, md metadata.MD) string {
+	requestMetadata := i.defaultRequestMetadata
+	contextOverridesInvocation := false
+	if override, ok := RequestMetadataFromContext(ctx); ok {
+		if override.ToolInvocationID != "" {
+			requestMetadata.ToolInvocationID = override.ToolInvocationID
+			contextOverridesInvocation = true
+		}
+		if override.ActionID != "" {
+			requestMetadata.ActionID = override.ActionID
+		}
+		if override.ActionMnemonic != "" {
+			requestMetadata.ActionMnemonic = override.ActionMnemonic
+		}
+		if override.TargetID != "" {
+			requestMetadata.TargetID = override.TargetID
+		}
+	}
+
+	var caller *remoteexecution_proto.RequestMetadata
+	values := md.Get(requestMetadataHeaderKey)
+	// Proxy-style rules_img services (notably the blob-cache service) pass the
+	// server request context directly to their downstream gRPC client. Preserve
+	// the caller's RequestMetadata across that hop even though gRPC keeps
+	// incoming and outgoing metadata in separate context values.
+	if len(values) == 0 {
+		if incomingMD, ok := metadata.FromIncomingContext(ctx); ok {
+			values = incomingMD.Get(requestMetadataHeaderKey)
+		}
+	}
+	if len(values) > 0 {
+		parsed := &remoteexecution_proto.RequestMetadata{}
+		if err := proto.Unmarshal([]byte(values[0]), parsed); err == nil {
+			caller = parsed
+		}
+	}
+	// A connection-level invocation ID is only a fallback. Proxy callers carry
+	// the invocation associated with the current request, while an explicit
+	// context value remains authoritative for direct client calls and workers.
+	if caller.GetToolInvocationId() != "" && !contextOverridesInvocation {
+		requestMetadata.ToolInvocationID = ""
+	}
+	return marshalRequestMetadata(mergeRequestMetadata(caller, requestMetadata))
 }
 
 // unaryAddHeaders injects headers into a unary gRPC call.
@@ -47,10 +148,12 @@ func (i *authenticatingInterceptor) unaryAddHeaders(ctx context.Context, method 
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		md = metadata.New(nil)
+	} else {
+		md = md.Copy()
 	}
 
 	md = addCredentialsToMD(ctx, cc.Target(), method, md, i.helper)
-	md.Set(requestMetadataHeaderKey, requestMetadataBin)
+	md.Set(requestMetadataHeaderKey, i.requestMetadataBin(ctx, md))
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	return invoker(ctx, method, req, reply, cc, opts...)
@@ -61,10 +164,12 @@ func (i *authenticatingInterceptor) streamAddHeaders(ctx context.Context, desc *
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		md = metadata.New(nil)
+	} else {
+		md = md.Copy()
 	}
 
 	md = addCredentialsToMD(ctx, cc.Target(), method, md, i.helper)
-	md.Set(requestMetadataHeaderKey, requestMetadataBin)
+	md.Set(requestMetadataHeaderKey, i.requestMetadataBin(ctx, md))
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	return streamer(ctx, desc, cc, method, opts...)
@@ -105,7 +210,24 @@ func addCredentialsToMD(ctx context.Context, target, method string, md metadata.
 }
 
 func DialOptions(helper credential.Helper) []grpc.DialOption {
-	interceptor := &authenticatingInterceptor{helper: helper}
+	return DialOptionsWithRequestMetadata(helper, RequestMetadata{})
+}
+
+// DialOptionsWithToolInvocationID returns dial options that attach credentials
+// and RequestMetadata to every unary and streaming RPC. A non-empty invocation
+// ID is used by default and may be overridden per request with
+// WithToolInvocationID.
+func DialOptionsWithToolInvocationID(helper credential.Helper, toolInvocationID string) []grpc.DialOption {
+	return DialOptionsWithRequestMetadata(helper, RequestMetadata{ToolInvocationID: toolInvocationID})
+}
+
+// DialOptionsWithRequestMetadata returns dial options that attach credentials
+// and merged RequestMetadata to every unary and streaming RPC.
+func DialOptionsWithRequestMetadata(helper credential.Helper, requestMetadata RequestMetadata) []grpc.DialOption {
+	interceptor := &authenticatingInterceptor{
+		helper:                 helper,
+		defaultRequestMetadata: requestMetadata,
+	}
 	return []grpc.DialOption{
 		grpc.WithUnaryInterceptor(interceptor.unaryAddHeaders),
 		grpc.WithStreamInterceptor(interceptor.streamAddHeaders),

--- a/img_tool/pkg/auth/grpcheaderinterceptor/grpcheaderinterceptor_test.go
+++ b/img_tool/pkg/auth/grpcheaderinterceptor/grpcheaderinterceptor_test.go
@@ -1,0 +1,230 @@
+package grpcheaderinterceptor
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/credential"
+	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
+)
+
+func TestRequestMetadataOnUnaryAndStreamingRPCs(t *testing.T) {
+	conn, err := grpc.NewClient("dns:cache.example", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("creating test client connection: %v", err)
+	}
+	defer conn.Close()
+
+	interceptor := &authenticatingInterceptor{
+		helper: credential.NopHelper(),
+		defaultRequestMetadata: RequestMetadata{
+			ToolInvocationID: "default-invocation",
+			ActionID:         "rules_img:deploy",
+			ActionMnemonic:   "ImgDeploy",
+			TargetID:         "//images:app",
+		},
+	}
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		call func(context.Context, func(context.Context)) error
+		want string
+	}{
+		{
+			name: "unary default",
+			ctx:  context.Background(),
+			call: func(ctx context.Context, capture func(context.Context)) error {
+				return interceptor.unaryAddHeaders(ctx, "/example.CAS/FindMissingBlobs", nil, nil, conn,
+					func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+						capture(ctx)
+						return nil
+					})
+			},
+			want: "default-invocation",
+		},
+		{
+			name: "unary context override",
+			ctx:  WithToolInvocationID(context.Background(), "request-invocation"),
+			call: func(ctx context.Context, capture func(context.Context)) error {
+				return interceptor.unaryAddHeaders(ctx, "/example.CAS/BatchReadBlobs", nil, nil, conn,
+					func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+						capture(ctx)
+						return nil
+					})
+			},
+			want: "request-invocation",
+		},
+		{
+			name: "stream default",
+			ctx:  context.Background(),
+			call: func(ctx context.Context, capture func(context.Context)) error {
+				_, err := interceptor.streamAddHeaders(ctx, &grpc.StreamDesc{}, conn, "/google.bytestream.ByteStream/Read",
+					func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+						capture(ctx)
+						return nil, nil
+					})
+				return err
+			},
+			want: "default-invocation",
+		},
+		{
+			name: "stream context override",
+			ctx:  WithToolInvocationID(context.Background(), "request-invocation"),
+			call: func(ctx context.Context, capture func(context.Context)) error {
+				_, err := interceptor.streamAddHeaders(ctx, &grpc.StreamDesc{}, conn, "/google.bytestream.ByteStream/Write",
+					func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+						capture(ctx)
+						return nil, nil
+					})
+				return err
+			},
+			want: "request-invocation",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured context.Context
+			if err := tc.call(tc.ctx, func(ctx context.Context) { captured = ctx }); err != nil {
+				t.Fatalf("interceptor call failed: %v", err)
+			}
+			got := requestMetadataFromContext(t, captured)
+			if got.GetToolInvocationId() != tc.want {
+				t.Errorf("tool_invocation_id = %q, want %q", got.GetToolInvocationId(), tc.want)
+			}
+			if got.GetToolDetails().GetToolName() != "rules_img" {
+				t.Errorf("tool_name = %q, want rules_img", got.GetToolDetails().GetToolName())
+			}
+			if got.GetActionId() != "rules_img:deploy" || got.GetActionMnemonic() != "ImgDeploy" || got.GetTargetId() != "//images:app" {
+				t.Errorf("logical action metadata = (%q, %q, %q), want rules_img deploy metadata", got.GetActionId(), got.GetActionMnemonic(), got.GetTargetId())
+			}
+		})
+	}
+}
+
+func TestRequestMetadataMergesCallerMetadataIntoSingleHeader(t *testing.T) {
+	caller := &remoteexecution_proto.RequestMetadata{
+		ToolDetails:             &remoteexecution_proto.ToolDetails{ToolName: "caller", ToolVersion: "1"},
+		ActionId:                "caller-action",
+		ActionMnemonic:          "CallerMnemonic",
+		TargetId:                "//caller:target",
+		ToolInvocationId:        "caller-invocation",
+		CorrelatedInvocationsId: "correlated",
+		ConfigurationId:         "configuration",
+	}
+	callerBytes, err := proto.Marshal(caller)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(requestMetadataHeaderKey, string(callerBytes)))
+	ctx = WithRequestMetadata(ctx, RequestMetadata{
+		ToolInvocationID: "rules-img-invocation",
+		ActionID:         "rules_img:deploy",
+		ActionMnemonic:   "ImgDeploy",
+		TargetID:         "rules_img",
+	})
+
+	interceptor := &authenticatingInterceptor{helper: credential.NopHelper()}
+	conn, err := grpc.NewClient("dns:cache.example", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	var captured context.Context
+	if err := interceptor.unaryAddHeaders(ctx, "/example.CAS/BatchReadBlobs", nil, nil, conn,
+		func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			captured = ctx
+			return nil
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := requestMetadataFromContext(t, captured)
+	if got.GetToolDetails().GetToolName() != "rules_img" {
+		t.Errorf("tool_name = %q, want rules_img", got.GetToolDetails().GetToolName())
+	}
+	if got.GetToolInvocationId() != "rules-img-invocation" {
+		t.Errorf("tool_invocation_id = %q, want rules-img-invocation", got.GetToolInvocationId())
+	}
+	if got.GetActionId() != caller.GetActionId() || got.GetActionMnemonic() != caller.GetActionMnemonic() || got.GetTargetId() != caller.GetTargetId() {
+		t.Errorf("caller action metadata was not preserved: %v", got)
+	}
+	if got.GetCorrelatedInvocationsId() != "correlated" || got.GetConfigurationId() != "configuration" {
+		t.Errorf("caller correlation/configuration metadata was not preserved: %v", got)
+	}
+}
+
+func TestRequestMetadataForwardsIncomingCallerMetadata(t *testing.T) {
+	caller := &remoteexecution_proto.RequestMetadata{
+		ToolInvocationId:        "caller-invocation",
+		ActionId:                "caller-action",
+		ActionMnemonic:          "CallerMnemonic",
+		TargetId:                "//caller:target",
+		CorrelatedInvocationsId: "correlated",
+	}
+	callerBytes, err := proto.Marshal(caller)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(requestMetadataHeaderKey, string(callerBytes)))
+
+	interceptor := &authenticatingInterceptor{
+		helper: credential.NopHelper(),
+		defaultRequestMetadata: RequestMetadata{
+			ToolInvocationID: "server-startup-invocation",
+			ActionID:         "rules_img:registry",
+			ActionMnemonic:   "ImgRegistry",
+			TargetID:         "rules_img",
+		},
+	}
+	conn, err := grpc.NewClient("dns:cache.example", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	var captured context.Context
+	if err := interceptor.unaryAddHeaders(ctx, "/example.CAS/FindMissingBlobs", nil, nil, conn,
+		func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			captured = ctx
+			return nil
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := requestMetadataFromContext(t, captured)
+	if got.GetToolInvocationId() != caller.GetToolInvocationId() {
+		t.Errorf("tool_invocation_id = %q, want %q", got.GetToolInvocationId(), caller.GetToolInvocationId())
+	}
+	if got.GetActionId() != caller.GetActionId() || got.GetActionMnemonic() != caller.GetActionMnemonic() || got.GetTargetId() != caller.GetTargetId() {
+		t.Errorf("caller action metadata was not preserved: %v", got)
+	}
+	if got.GetCorrelatedInvocationsId() != caller.GetCorrelatedInvocationsId() {
+		t.Errorf("correlated_invocations_id = %q, want %q", got.GetCorrelatedInvocationsId(), caller.GetCorrelatedInvocationsId())
+	}
+	if got.GetToolDetails().GetToolName() != "rules_img" {
+		t.Errorf("tool_name = %q, want rules_img", got.GetToolDetails().GetToolName())
+	}
+}
+
+func requestMetadataFromContext(t *testing.T, ctx context.Context) *remoteexecution_proto.RequestMetadata {
+	t.Helper()
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("outgoing metadata is missing")
+	}
+	values := md.Get(requestMetadataHeaderKey)
+	if len(values) != 1 {
+		t.Fatalf("request metadata header has %d values, want 1", len(values))
+	}
+	requestMetadata := &remoteexecution_proto.RequestMetadata{}
+	if err := proto.Unmarshal([]byte(values[0]), requestMetadata); err != nil {
+		t.Fatalf("decoding request metadata: %v", err)
+	}
+	return requestMetadata
+}

--- a/img_tool/pkg/auth/protohelper/protohelper.go
+++ b/img_tool/pkg/auth/protohelper/protohelper.go
@@ -20,6 +20,63 @@ import (
 )
 
 func Client(uri string, helper credhelper.Helper, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return client(uri, helper, grpcheaderinterceptor.RequestMetadata{}, opts...)
+}
+
+// ClientWithToolInvocationID creates a gRPC client whose requests carry the
+// supplied REAPI RequestMetadata.tool_invocation_id by default.
+func ClientWithToolInvocationID(uri string, helper credhelper.Helper, toolInvocationID string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return client(uri, helper, grpcheaderinterceptor.RequestMetadata{ToolInvocationID: toolInvocationID}, opts...)
+}
+
+// ClientWithRequestMetadata creates a gRPC client whose requests carry the
+// supplied logical-operation metadata by default.
+func ClientWithRequestMetadata(uri string, helper credhelper.Helper, requestMetadata RequestMetadata, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return client(uri, helper, requestMetadata.interceptorMetadata(), opts...)
+}
+
+// RequestMetadata identifies one logical rules_img operation. The same values
+// are attached to unary RPCs, ByteStream RPCs, lazy reads, and retries.
+type RequestMetadata struct {
+	ToolInvocationID string
+	ActionID         string
+	ActionMnemonic   string
+	TargetID         string
+}
+
+func (m RequestMetadata) interceptorMetadata() grpcheaderinterceptor.RequestMetadata {
+	return grpcheaderinterceptor.RequestMetadata{
+		ToolInvocationID: m.ToolInvocationID,
+		ActionID:         m.ActionID,
+		ActionMnemonic:   m.ActionMnemonic,
+		TargetID:         m.TargetID,
+	}
+}
+
+// WithRequestMetadata returns a context that identifies one logical rules_img
+// operation on every outgoing cache request.
+func WithRequestMetadata(ctx context.Context, requestMetadata RequestMetadata) context.Context {
+	return grpcheaderinterceptor.WithRequestMetadata(ctx, requestMetadata.interceptorMetadata())
+}
+
+// RequestMetadataFromContext returns rules_img metadata stored on ctx.
+func RequestMetadataFromContext(ctx context.Context) (RequestMetadata, bool) {
+	requestMetadata, ok := grpcheaderinterceptor.RequestMetadataFromContext(ctx)
+	return RequestMetadata{
+		ToolInvocationID: requestMetadata.ToolInvocationID,
+		ActionID:         requestMetadata.ActionID,
+		ActionMnemonic:   requestMetadata.ActionMnemonic,
+		TargetID:         requestMetadata.TargetID,
+	}, ok
+}
+
+// WithToolInvocationID returns a context that overrides the connection's
+// default RequestMetadata.tool_invocation_id for RPCs made with that context.
+func WithToolInvocationID(ctx context.Context, toolInvocationID string) context.Context {
+	return grpcheaderinterceptor.WithToolInvocationID(ctx, toolInvocationID)
+}
+
+func client(uri string, helper credhelper.Helper, requestMetadata grpcheaderinterceptor.RequestMetadata, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	opts = slices.Clone(opts)
 
 	parsed, err := url.Parse(uri)
@@ -49,7 +106,7 @@ func Client(uri string, helper credhelper.Helper, opts ...grpc.DialOption) (*grp
 		opts = append(opts, grpc.WithPerRPCCredentials(basicAuthFromUserinfo(parsed.User)))
 	}
 
-	opts = append(opts, grpcheaderinterceptor.DialOptions(helper)...)
+	opts = append(opts, grpcheaderinterceptor.DialOptionsWithRequestMetadata(helper, requestMetadata)...)
 
 	// Keepalive, so a peer that goes away during a long transfer is noticed rather
 	// than leaving a read blocked forever: with a stream in flight and no data

--- a/img_tool/pkg/auth/protohelper/protohelper.go
+++ b/img_tool/pkg/auth/protohelper/protohelper.go
@@ -58,6 +58,63 @@ func maxRecvMsgSizeFromEnv() int {
 }
 
 func Client(uri string, helper credhelper.Helper, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return client(uri, helper, grpcheaderinterceptor.RequestMetadata{}, opts...)
+}
+
+// ClientWithToolInvocationID creates a gRPC client whose requests carry the
+// supplied REAPI RequestMetadata.tool_invocation_id by default.
+func ClientWithToolInvocationID(uri string, helper credhelper.Helper, toolInvocationID string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return client(uri, helper, grpcheaderinterceptor.RequestMetadata{ToolInvocationID: toolInvocationID}, opts...)
+}
+
+// ClientWithRequestMetadata creates a gRPC client whose requests carry the
+// supplied logical-operation metadata by default.
+func ClientWithRequestMetadata(uri string, helper credhelper.Helper, requestMetadata RequestMetadata, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return client(uri, helper, requestMetadata.interceptorMetadata(), opts...)
+}
+
+// RequestMetadata identifies one logical rules_img operation. The same values
+// are attached to unary RPCs, ByteStream RPCs, lazy reads, and retries.
+type RequestMetadata struct {
+	ToolInvocationID string
+	ActionID         string
+	ActionMnemonic   string
+	TargetID         string
+}
+
+func (m RequestMetadata) interceptorMetadata() grpcheaderinterceptor.RequestMetadata {
+	return grpcheaderinterceptor.RequestMetadata{
+		ToolInvocationID: m.ToolInvocationID,
+		ActionID:         m.ActionID,
+		ActionMnemonic:   m.ActionMnemonic,
+		TargetID:         m.TargetID,
+	}
+}
+
+// WithRequestMetadata returns a context that identifies one logical rules_img
+// operation on every outgoing cache request.
+func WithRequestMetadata(ctx context.Context, requestMetadata RequestMetadata) context.Context {
+	return grpcheaderinterceptor.WithRequestMetadata(ctx, requestMetadata.interceptorMetadata())
+}
+
+// RequestMetadataFromContext returns rules_img metadata stored on ctx.
+func RequestMetadataFromContext(ctx context.Context) (RequestMetadata, bool) {
+	requestMetadata, ok := grpcheaderinterceptor.RequestMetadataFromContext(ctx)
+	return RequestMetadata{
+		ToolInvocationID: requestMetadata.ToolInvocationID,
+		ActionID:         requestMetadata.ActionID,
+		ActionMnemonic:   requestMetadata.ActionMnemonic,
+		TargetID:         requestMetadata.TargetID,
+	}, ok
+}
+
+// WithToolInvocationID returns a context that overrides the connection's
+// default RequestMetadata.tool_invocation_id for RPCs made with that context.
+func WithToolInvocationID(ctx context.Context, toolInvocationID string) context.Context {
+	return grpcheaderinterceptor.WithToolInvocationID(ctx, toolInvocationID)
+}
+
+func client(uri string, helper credhelper.Helper, requestMetadata grpcheaderinterceptor.RequestMetadata, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	// Ours goes first so a caller passing its own MaxCallRecvMsgSize wins: grpc
 	// applies call options in order and the last one set takes effect.
 	opts = append([]grpc.DialOption{
@@ -91,7 +148,7 @@ func Client(uri string, helper credhelper.Helper, opts ...grpc.DialOption) (*grp
 		opts = append(opts, grpc.WithPerRPCCredentials(basicAuthFromUserinfo(parsed.User)))
 	}
 
-	opts = append(opts, grpcheaderinterceptor.DialOptions(helper)...)
+	opts = append(opts, grpcheaderinterceptor.DialOptionsWithRequestMetadata(helper, requestMetadata)...)
 
 	// Keepalive, so a peer that goes away during a long transfer is noticed rather
 	// than leaving a read blocked forever: with a stream in flight and no data

--- a/img_tool/pkg/cas/BUILD.bazel
+++ b/img_tool/pkg/cas/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     ],
     embed = [":cas"],
     deps = [
+        "//pkg/auth/protohelper",
         "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",

--- a/img_tool/pkg/cas/BUILD.bazel
+++ b/img_tool/pkg/cas/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     ],
     embed = [":cas"],
     deps = [
+        "//pkg/auth/protohelper",
         "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",

--- a/img_tool/pkg/cas/cache.go
+++ b/img_tool/pkg/cas/cache.go
@@ -306,7 +306,7 @@ func (c *CachingReader) ReaderForBlob(ctx context.Context, digest Digest) (io.Re
 			return file, nil
 		}
 
-		fetch, joined, inStore := c.fetchFor(digest)
+		fetch, joined, inStore := c.fetchFor(ctx, digest)
 		if inStore {
 			continue // another reader just finalized it; store.open will find it
 		}
@@ -330,7 +330,7 @@ func (c *CachingReader) ReaderForBlob(ctx context.Context, digest Digest) (io.Re
 // and reports whether it joined an existing one. It returns a nil fetch and
 // inStore==false if the blob cannot be cached locally, or inStore==true if the
 // blob is already in the store and the caller should read it from there.
-func (c *CachingReader) fetchFor(digest Digest) (fetch *blobFetch, joined, inStore bool) {
+func (c *CachingReader) fetchFor(ctx context.Context, digest Digest) (fetch *blobFetch, joined, inStore bool) {
 	key := digest.cacheKey()
 
 	c.mu.Lock()
@@ -347,7 +347,7 @@ func (c *CachingReader) fetchFor(digest Digest) (fetch *blobFetch, joined, inSto
 	if c.store.has(digest) {
 		return nil, false, true
 	}
-	newFetch := c.startFetch(digest, key)
+	newFetch := c.startFetch(ctx, digest, key)
 	if newFetch == nil {
 		return nil, false, false
 	}
@@ -356,7 +356,7 @@ func (c *CachingReader) fetchFor(digest Digest) (fetch *blobFetch, joined, inSto
 }
 
 // startFetch begins fetching a blob into a temp file. c.mu must be held.
-func (c *CachingReader) startFetch(digest Digest, key string) *blobFetch {
+func (c *CachingReader) startFetch(requestCtx context.Context, digest Digest, key string) *blobFetch {
 	file, err := c.store.createTemp(digest.SizeBytes)
 	if err != nil {
 		if !errors.Is(err, errDiskCacheDisabled) {
@@ -365,13 +365,22 @@ func (c *CachingReader) startFetch(digest Digest, key string) *blobFetch {
 		}
 		return nil
 	}
-	ctx, cancel := context.WithCancel(c.baseCtx)
+	// The fetch may be shared with callers that arrive after the one that starts
+	// it, so it must not inherit that first caller's cancellation or deadline.
+	// Keep its values, notably REAPI RequestMetadata, while making Close and an
+	// abandoned fetch responsible for cancellation.
+	ctx, cancel := context.WithCancel(context.WithoutCancel(requestCtx))
+	stopBaseCancel := context.AfterFunc(c.baseCtx, cancel)
+	cancelFetch := func() {
+		stopBaseCancel()
+		cancel()
+	}
 	fetch := &blobFetch{
 		cache:    c,
 		digest:   digest,
 		key:      key,
 		tempPath: file.Name(),
-		cancel:   cancel,
+		cancel:   cancelFetch,
 		changed:  make(chan struct{}),
 	}
 	c.counters.fetches.Add(1)
@@ -440,6 +449,7 @@ type fetchState struct {
 
 func (b *blobFetch) run(ctx context.Context, file *os.File) {
 	defer b.cache.running.Done()
+	defer b.cancel()
 	err := b.stream(ctx, file)
 	file.Close()
 	b.finish(err)

--- a/img_tool/pkg/cas/cache_test.go
+++ b/img_tool/pkg/cas/cache_test.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
 )
 
 // fakeBlobs is a BlobSource serving blobs from memory. It counts reads per
@@ -29,6 +31,7 @@ type fakeBlobs struct {
 	data      map[string][]byte // hex digest -> served content
 	reads     map[string]int
 	findCalls [][]Digest
+	metadata  []protohelper.RequestMetadata
 }
 
 func newFakeBlobs(blobs ...[]byte) *fakeBlobs {
@@ -74,6 +77,9 @@ func (f *fakeBlobs) ReadBlob(ctx context.Context, digest Digest) ([]byte, error)
 func (f *fakeBlobs) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, error) {
 	f.mu.Lock()
 	f.reads[digest.hexHash()]++
+	if requestMetadata, ok := protohelper.RequestMetadataFromContext(ctx); ok {
+		f.metadata = append(f.metadata, requestMetadata)
+	}
 	data, found := f.data[digest.hexHash()]
 	f.mu.Unlock()
 
@@ -84,6 +90,12 @@ func (f *fakeBlobs) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCl
 		return nil, fmt.Errorf("fake: blob %s not found", digest.hexHash())
 	}
 	return &fakeBlobReader{source: f, data: data, ctx: ctx}, nil
+}
+
+func (f *fakeBlobs) requestMetadata() []protohelper.RequestMetadata {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.metadata)
 }
 
 func (f *fakeBlobs) readCount(digest Digest) int {
@@ -257,6 +269,31 @@ func TestCachingReaderCachesBlobOnDisk(t *testing.T) {
 	stats := cache.Stats()
 	if stats.Hits != 1 || stats.Fetches != 1 {
 		t.Errorf("stats = %+v, want 1 hit and 1 fetch", stats)
+	}
+}
+
+func TestCachingReaderPropagatesRequestMetadataToCacheMiss(t *testing.T) {
+	blob := blobContent(7, 256)
+	digest := blobDigest(blob)
+	source := newFakeBlobs(blob)
+	cache := newTestCache(t, source)
+
+	want := protohelper.RequestMetadata{
+		ToolInvocationID: "invocation",
+		ActionID:         "rules_img:deploy:app",
+		ActionMnemonic:   "ImgDeploy",
+		TargetID:         "app",
+	}
+	ctx := protohelper.WithRequestMetadata(context.Background(), want)
+	reader, err := cache.ReaderForBlob(ctx, digest)
+	if err != nil {
+		t.Fatalf("ReaderForBlob: %v", err)
+	}
+	readAllAndClose(t, reader)
+
+	got := source.requestMetadata()
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("upstream request metadata = %+v, want [%+v]", got, want)
 	}
 }
 

--- a/img_tool/pkg/cas/cache_test.go
+++ b/img_tool/pkg/cas/cache_test.go
@@ -14,6 +14,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
 )
 
 // fakeBlobs is a BlobSource serving blobs from memory. It counts reads per
@@ -30,6 +32,7 @@ type fakeBlobs struct {
 	data      map[string][]byte // hex digest -> served content
 	reads     map[string]int
 	findCalls [][]Digest
+	metadata  []protohelper.RequestMetadata
 }
 
 func newFakeBlobs(blobs ...[]byte) *fakeBlobs {
@@ -75,6 +78,9 @@ func (f *fakeBlobs) ReadBlob(ctx context.Context, digest Digest) ([]byte, error)
 func (f *fakeBlobs) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, error) {
 	f.mu.Lock()
 	f.reads[digest.hexHash()]++
+	if requestMetadata, ok := protohelper.RequestMetadataFromContext(ctx); ok {
+		f.metadata = append(f.metadata, requestMetadata)
+	}
 	data, found := f.data[digest.hexHash()]
 	f.mu.Unlock()
 
@@ -97,6 +103,12 @@ func (f *fakeBlobs) ReaderForBlobs(ctx context.Context, digests []Digest) (io.Re
 		buf.Write(data)
 	}
 	return io.NopCloser(&buf), nil
+}
+
+func (f *fakeBlobs) requestMetadata() []protohelper.RequestMetadata {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.metadata)
 }
 
 func (f *fakeBlobs) readCount(digest Digest) int {
@@ -270,6 +282,31 @@ func TestCachingReaderCachesBlobOnDisk(t *testing.T) {
 	stats := cache.Stats()
 	if stats.Hits != 1 || stats.Fetches != 1 {
 		t.Errorf("stats = %+v, want 1 hit and 1 fetch", stats)
+	}
+}
+
+func TestCachingReaderPropagatesRequestMetadataToCacheMiss(t *testing.T) {
+	blob := blobContent(7, 256)
+	digest := blobDigest(blob)
+	source := newFakeBlobs(blob)
+	cache := newTestCache(t, source)
+
+	want := protohelper.RequestMetadata{
+		ToolInvocationID: "invocation",
+		ActionID:         "rules_img:deploy:app",
+		ActionMnemonic:   "ImgDeploy",
+		TargetID:         "app",
+	}
+	ctx := protohelper.WithRequestMetadata(context.Background(), want)
+	reader, err := cache.ReaderForBlob(ctx, digest)
+	if err != nil {
+		t.Fatalf("ReaderForBlob: %v", err)
+	}
+	readAllAndClose(t, reader)
+
+	got := source.requestMetadata()
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("upstream request metadata = %+v, want [%+v]", got, want)
 	}
 }
 

--- a/img_tool/pkg/cas/read_test.go
+++ b/img_tool/pkg/cas/read_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
 	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
 )
 
@@ -29,14 +30,16 @@ type fakeByteStreamClient struct {
 	failAfterBytes []int
 	failErr        error
 
-	conns   int
-	offsets []int64 // recorded ReadOffset per connection, in order
+	conns    int
+	offsets  []int64 // recorded ReadOffset per connection, in order
+	contexts []context.Context
 }
 
 func (f *fakeByteStreamClient) Read(ctx context.Context, in *bytestream_proto.ReadRequest, _ ...grpc.CallOption) (bytestream_proto.ByteStream_ReadClient, error) {
 	idx := f.conns
 	f.conns++
 	f.offsets = append(f.offsets, in.ReadOffset)
+	f.contexts = append(f.contexts, ctx)
 	failAfter := -1
 	if idx < len(f.failAfterBytes) {
 		failAfter = f.failAfterBytes[idx]
@@ -192,7 +195,12 @@ func TestStreamReadReconnectResumesAfterRST(t *testing.T) {
 	}
 	c := testCAS(fake, nil)
 
-	rc, err := c.streamReadOne(context.Background(), SHA256(make([]byte, 32), int64(len(blob))))
+	ctx := protohelper.WithRequestMetadata(context.Background(), protohelper.RequestMetadata{
+		ToolInvocationID: "invocation",
+		ActionID:         "rules_img:deploy",
+		ActionMnemonic:   "ImgDeploy",
+	})
+	rc, err := c.streamReadOne(ctx, SHA256(make([]byte, 32), int64(len(blob))))
 	if err != nil {
 		t.Fatalf("streamReadOne: %v", err)
 	}
@@ -210,6 +218,15 @@ func TestStreamReadReconnectResumesAfterRST(t *testing.T) {
 	wantOffsets := []int64{0, 100, 350}
 	if !reflect.DeepEqual(fake.offsets, wantOffsets) {
 		t.Fatalf("resume offsets = %v, want %v", fake.offsets, wantOffsets)
+	}
+	if len(fake.contexts) != len(wantOffsets) {
+		t.Fatalf("request contexts = %d, want %d", len(fake.contexts), len(wantOffsets))
+	}
+	for i, requestCtx := range fake.contexts {
+		got, ok := protohelper.RequestMetadataFromContext(requestCtx)
+		if !ok || got.ToolInvocationID != "invocation" || got.ActionID != "rules_img:deploy" {
+			t.Errorf("retry %d request metadata = %+v, present=%v", i, got, ok)
+		}
 	}
 }
 

--- a/img_tool/pkg/cas/read_test.go
+++ b/img_tool/pkg/cas/read_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
 	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
 )
 
@@ -29,14 +30,16 @@ type fakeByteStreamClient struct {
 	failAfterBytes []int
 	failErr        error
 
-	conns   int
-	offsets []int64 // recorded ReadOffset per connection, in order
+	conns    int
+	offsets  []int64 // recorded ReadOffset per connection, in order
+	contexts []context.Context
 }
 
 func (f *fakeByteStreamClient) Read(ctx context.Context, in *bytestream_proto.ReadRequest, _ ...grpc.CallOption) (bytestream_proto.ByteStream_ReadClient, error) {
 	idx := f.conns
 	f.conns++
 	f.offsets = append(f.offsets, in.ReadOffset)
+	f.contexts = append(f.contexts, ctx)
 	failAfter := -1
 	if idx < len(f.failAfterBytes) {
 		failAfter = f.failAfterBytes[idx]
@@ -148,7 +151,12 @@ func TestStreamReadReconnectResumesAfterRST(t *testing.T) {
 	}
 	c := testCAS(fake, nil)
 
-	rc, err := c.streamReadOne(context.Background(), SHA256(make([]byte, 32), int64(len(blob))))
+	ctx := protohelper.WithRequestMetadata(context.Background(), protohelper.RequestMetadata{
+		ToolInvocationID: "invocation",
+		ActionID:         "rules_img:deploy",
+		ActionMnemonic:   "ImgDeploy",
+	})
+	rc, err := c.streamReadOne(ctx, SHA256(make([]byte, 32), int64(len(blob))))
 	if err != nil {
 		t.Fatalf("streamReadOne: %v", err)
 	}
@@ -166,6 +174,15 @@ func TestStreamReadReconnectResumesAfterRST(t *testing.T) {
 	wantOffsets := []int64{0, 100, 350}
 	if !reflect.DeepEqual(fake.offsets, wantOffsets) {
 		t.Fatalf("resume offsets = %v, want %v", fake.offsets, wantOffsets)
+	}
+	if len(fake.contexts) != len(wantOffsets) {
+		t.Fatalf("request contexts = %d, want %d", len(fake.contexts), len(wantOffsets))
+	}
+	for i, requestCtx := range fake.contexts {
+		got, ok := protohelper.RequestMetadataFromContext(requestCtx)
+		if !ok || got.ToolInvocationID != "invocation" || got.ActionID != "rules_img:deploy" {
+			t.Errorf("retry %d request metadata = %+v, present=%v", i, got, ok)
+		}
 	}
 }
 

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -964,7 +964,7 @@ func (b *Builder) layerFromCAS(desc api.Descriptor) (blobEntry, error) {
 	if err != nil {
 		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Err: err}
 	}
-	if missing, err := b.casReader.FindMissingBlobs(context.TODO(), []cas.Digest{digest}); err == nil && len(missing) > 0 {
+	if missing, err := b.casReader.FindMissingBlobs(b.context(), []cas.Digest{digest}); err == nil && len(missing) > 0 {
 		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Message: "blob not found in remote CAS"}
 	}
 	stats := b.stats
@@ -974,7 +974,7 @@ func (b *Builder) layerFromCAS(desc api.Descriptor) (blobEntry, error) {
 		stats:      stats,
 		Opener: func() (io.ReadCloser, error) {
 			stats.BlobsFromRemoteCache.Add(1)
-			return b.casReader.ReaderForBlob(context.TODO(), digest)
+			return b.casReader.ReaderForBlob(b.context(), digest)
 		},
 	}, nil
 }
@@ -1051,7 +1051,7 @@ func (b *Builder) blobFromCAS(desc api.Descriptor) (blobEntry, error) {
 	if err != nil {
 		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Err: err}
 	}
-	if missing, err := b.casReader.FindMissingBlobs(context.TODO(), []cas.Digest{digest}); err == nil && len(missing) > 0 {
+	if missing, err := b.casReader.FindMissingBlobs(b.context(), []cas.Digest{digest}); err == nil && len(missing) > 0 {
 		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Message: "blob not found in remote CAS"}
 	}
 	stats := b.stats
@@ -1061,7 +1061,7 @@ func (b *Builder) blobFromCAS(desc api.Descriptor) (blobEntry, error) {
 		stats:      stats,
 		Opener: func() (io.ReadCloser, error) {
 			stats.BlobsFromRemoteCache.Add(1)
-			return b.casReader.ReaderForBlob(context.TODO(), digest)
+			return b.casReader.ReaderForBlob(b.context(), digest)
 		},
 	}, nil
 }

--- a/img_tool/pkg/deployvfs/layersource_test.go
+++ b/img_tool/pkg/deployvfs/layersource_test.go
@@ -1,9 +1,12 @@
 package deployvfs
 
 import (
+	"context"
+	"io"
 	"testing"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
 )
 
 const testRegistryDigest = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
@@ -43,5 +46,58 @@ func TestLayerFromRegistryUnconfigured(t *testing.T) {
 		t.Error("expected error when no sources are configured")
 	} else if bse, ok := err.(*BlobSourceError); !ok || bse.Kind != BlobSourceUnconfigured {
 		t.Errorf("expected BlobSourceUnconfigured, got %v", err)
+	}
+}
+
+type contextRecordingCAS struct {
+	contexts []context.Context
+}
+
+func (c *contextRecordingCAS) FindMissingBlobs(ctx context.Context, _ []cas.Digest) ([]cas.Digest, error) {
+	c.contexts = append(c.contexts, ctx)
+	return nil, nil
+}
+
+func (c *contextRecordingCAS) ReadBlob(context.Context, cas.Digest) ([]byte, error) {
+	return nil, nil
+}
+
+func (c *contextRecordingCAS) ReaderForBlob(ctx context.Context, _ cas.Digest) (io.ReadCloser, error) {
+	c.contexts = append(c.contexts, ctx)
+	return io.NopCloser(nilReader{}), nil
+}
+
+func (c *contextRecordingCAS) ReaderForBlobs(ctx context.Context, _ []cas.Digest) (io.ReadCloser, error) {
+	c.contexts = append(c.contexts, ctx)
+	return io.NopCloser(nilReader{}), nil
+}
+
+type nilReader struct{}
+
+func (nilReader) Read([]byte) (int, error) { return 0, io.EOF }
+
+func TestLayerFromCASPropagatesBuilderContext(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "invocation")
+	reader := &contextRecordingCAS{}
+	b := NewBuilder(api.DeployManifest{}).WithContext(ctx).WithCASReader(reader)
+
+	entry, err := b.layerFromCAS(layerDesc())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := entry.Compressed()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob.Close()
+
+	if len(reader.contexts) != 2 {
+		t.Fatalf("CAS received %d contexts, want 2", len(reader.contexts))
+	}
+	for i, got := range reader.contexts {
+		if got.Value(contextKey{}) != "invocation" {
+			t.Errorf("CAS context %d did not preserve the builder context", i)
+		}
 	}
 }

--- a/img_tool/pkg/deployvfs/layersource_test.go
+++ b/img_tool/pkg/deployvfs/layersource_test.go
@@ -1,9 +1,12 @@
 package deployvfs
 
 import (
+	"context"
+	"io"
 	"testing"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
 )
 
 const testRegistryDigest = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
@@ -43,5 +46,53 @@ func TestLayerFromRegistryUnconfigured(t *testing.T) {
 		t.Error("expected error when no sources are configured")
 	} else if bse, ok := err.(*BlobSourceError); !ok || bse.Kind != BlobSourceUnconfigured {
 		t.Errorf("expected BlobSourceUnconfigured, got %v", err)
+	}
+}
+
+type contextRecordingCAS struct {
+	contexts []context.Context
+}
+
+func (c *contextRecordingCAS) FindMissingBlobs(ctx context.Context, _ []cas.Digest) ([]cas.Digest, error) {
+	c.contexts = append(c.contexts, ctx)
+	return nil, nil
+}
+
+func (c *contextRecordingCAS) ReadBlob(context.Context, cas.Digest) ([]byte, error) {
+	return nil, nil
+}
+
+func (c *contextRecordingCAS) ReaderForBlob(ctx context.Context, _ cas.Digest) (io.ReadCloser, error) {
+	c.contexts = append(c.contexts, ctx)
+	return io.NopCloser(nilReader{}), nil
+}
+
+type nilReader struct{}
+
+func (nilReader) Read([]byte) (int, error) { return 0, io.EOF }
+
+func TestLayerFromCASPropagatesBuilderContext(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "invocation")
+	reader := &contextRecordingCAS{}
+	b := NewBuilder(api.DeployManifest{}).WithContext(ctx).WithCASReader(reader)
+
+	entry, err := b.layerFromCAS(layerDesc())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := entry.Compressed()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob.Close()
+
+	if len(reader.contexts) != 2 {
+		t.Fatalf("CAS received %d contexts, want 2", len(reader.contexts))
+	}
+	for i, got := range reader.contexts {
+		if got.Value(contextKey{}) != "invocation" {
+			t.Errorf("CAS context %d did not preserve the builder context", i)
+		}
 	}
 }

--- a/img_tool/pkg/serve/bes/BUILD.bazel
+++ b/img_tool/pkg/serve/bes/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "bes",
@@ -6,11 +6,23 @@ go_library(
     importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/serve/bes",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/auth/protohelper",
         "//pkg/proto/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//pkg/proto/build_event_service",
         "//pkg/serve/bes/syncer",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/emptypb",
+        "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "bes_test",
+    srcs = ["bes_test.go"],
+    embed = [":bes"],
+    deps = [
+        "//pkg/auth/protohelper",
+        "//pkg/proto/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/img_tool/pkg/serve/bes/bes.go
+++ b/img_tool/pkg/serve/bes/bes.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
 	build_event_stream_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream"
 	bes_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/build_event_service"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/serve/bes/syncer"
@@ -29,9 +30,13 @@ const (
 	CommitModePerStream
 )
 
+type imageCommitter interface {
+	Commit(context.Context, string, int64) error
+}
+
 type BES struct {
 	bes_proto.UnimplementedPublishBuildEventServer
-	syncer     *syncer.Syncer
+	syncer     imageCommitter
 	commitMode CommitMode
 
 	// Global errgroup for background commits
@@ -132,7 +137,16 @@ func (b *BES) PublishBuildToolEventStream(stream bes_proto.PublishBuildEvent_Pub
 		if err := proto.Unmarshal(bazelEvent.Value, &buildEvent); err != nil {
 			return err
 		} else {
-			if err := b.processBuildEvent(&buildEvent, tracker, requestErrGroup, commitCtx); err != nil {
+			eventCtx := commitCtx
+			if invocationID := req.GetOrderedBuildEvent().GetStreamId().GetInvocationId(); invocationID != "" {
+				eventCtx = protohelper.WithRequestMetadata(eventCtx, protohelper.RequestMetadata{
+					ToolInvocationID: invocationID,
+					ActionID:         "rules_img:bes",
+					ActionMnemonic:   "ImgBESCommit",
+					TargetID:         "rules_img",
+				})
+			}
+			if err := b.processBuildEvent(&buildEvent, tracker, requestErrGroup, eventCtx); err != nil {
 				log.Printf("Error processing build event: %v", err)
 				// Continue processing other events even if one fails
 			}
@@ -187,6 +201,14 @@ func (b *BES) processBuildEvent(event *build_event_stream_proto.BuildEvent, trac
 		if err != nil {
 			return fmt.Errorf("failed to hash event ID: %w", err)
 		}
+		targetID := event.Id.GetTargetCompleted().GetLabel()
+		requestMetadata, _ := protohelper.RequestMetadataFromContext(commitCtx)
+		requestMetadata.ActionMnemonic = "ImgBESCommit"
+		requestMetadata.ActionID = "rules_img:bes:" + idHash[:12]
+		if targetID != "" {
+			requestMetadata.TargetID = targetID
+		}
+		commitCtx = protohelper.WithRequestMetadata(commitCtx, requestMetadata)
 		// Check if this matches a TargetConfigured event
 		// seen earlier.
 		if !tracker.hasTargetCompleted(event.Id) {

--- a/img_tool/pkg/serve/bes/bes_test.go
+++ b/img_tool/pkg/serve/bes/bes_test.go
@@ -1,0 +1,74 @@
+package bes
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
+	build_event_stream_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream"
+)
+
+type recordingCommitter struct {
+	ctx context.Context
+}
+
+func (c *recordingCommitter) Commit(ctx context.Context, _ string, _ int64) error {
+	c.ctx = ctx
+	return nil
+}
+
+func TestProcessBuildEventPropagatesInvocationToCommit(t *testing.T) {
+	completedID := &build_event_stream_proto.BuildEventId{
+		Id: &build_event_stream_proto.BuildEventId_TargetCompleted{
+			TargetCompleted: &build_event_stream_proto.BuildEventId_TargetCompletedId{Label: "//images:app"},
+		},
+	}
+	fileSetID := &build_event_stream_proto.BuildEventId_NamedSetOfFilesId{Id: "outputs"}
+	tracker := newTracker()
+	if err := tracker.trackTargetCompleted(completedID); err != nil {
+		t.Fatal(err)
+	}
+	tracker.namedSets[fileSetID.Id] = &build_event_stream_proto.NamedSetOfFiles{
+		Files: []*build_event_stream_proto.File{{Digest: strings.Repeat("a", 64), Length: 123}},
+	}
+	event := &build_event_stream_proto.BuildEvent{
+		Id: completedID,
+		Payload: &build_event_stream_proto.BuildEvent_Completed{Completed: &build_event_stream_proto.TargetComplete{
+			Success: true,
+			OutputGroup: []*build_event_stream_proto.OutputGroup{{
+				Name:     "default",
+				FileSets: []*build_event_stream_proto.BuildEventId_NamedSetOfFilesId{fileSetID},
+			}},
+		}},
+	}
+
+	committer := &recordingCommitter{}
+	b := &BES{syncer: committer}
+	group, groupCtx := errgroup.WithContext(context.Background())
+	groupCtx = protohelper.WithRequestMetadata(groupCtx, protohelper.RequestMetadata{
+		ToolInvocationID: "invocation-id",
+		ActionID:         "rules_img:bes",
+		ActionMnemonic:   "ImgBESCommit",
+		TargetID:         "rules_img",
+	})
+	if err := b.processBuildEvent(event, tracker, group, groupCtx); err != nil {
+		t.Fatal(err)
+	}
+	if err := group.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := protohelper.RequestMetadataFromContext(committer.ctx)
+	if !ok {
+		t.Fatal("commit context is missing request metadata")
+	}
+	if got.ToolInvocationID != "invocation-id" || got.ActionMnemonic != "ImgBESCommit" || got.TargetID != "//images:app" {
+		t.Errorf("commit request metadata = %+v", got)
+	}
+	if !strings.HasPrefix(got.ActionID, "rules_img:bes:") || len(got.ActionID) != len("rules_img:bes:")+12 {
+		t.Errorf("action ID = %q, want logical target event ID", got.ActionID)
+	}
+}

--- a/img_tool/pkg/serve/bes/syncer/BUILD.bazel
+++ b/img_tool/pkg/serve/bes/syncer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "syncer",
@@ -15,5 +15,18 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/types",
         "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "syncer_test",
+    srcs = ["syncer_test.go"],
+    embed = [":syncer"],
+    deps = [
+        "//pkg/api",
+        "//pkg/auth/protohelper",
+        "//pkg/cas",
+        "@com_github_google_go_containerregistry//pkg/v1:pkg",
+        "@com_github_google_go_containerregistry//pkg/v1/types",
     ],
 )

--- a/img_tool/pkg/serve/bes/syncer/syncer.go
+++ b/img_tool/pkg/serve/bes/syncer/syncer.go
@@ -69,7 +69,7 @@ func makeTagKey(ref name.Repository, tag string) string {
 // The syncer maintains thread-safe state across multiple concurrent operations
 // and provides graceful shutdown capabilities.
 type Syncer struct {
-	casClient *cas.CAS
+	casClient casClient
 
 	// Memory cache for small metadata (manifests, configs)
 	metadataCache map[string][]byte
@@ -93,6 +93,11 @@ type Syncer struct {
 	workerCount int
 	shutdown    chan struct{}
 	workerWg    sync.WaitGroup
+}
+
+type casClient interface {
+	ReadBlob(context.Context, cas.Digest) ([]byte, error)
+	ReaderForBlob(context.Context, cas.Digest) (io.ReadCloser, error)
 }
 
 // New creates a new Syncer instance with the default worker count of 4.
@@ -412,6 +417,7 @@ func (s *Syncer) pushImage(ctx context.Context, ref name.Repository, pushOp api.
 	// Create and push manifest
 	img := &casImage{
 		syncer:       s,
+		ctx:          ctx,
 		manifest:     &manifest,
 		manifestData: manifestData,
 		pushOp:       pushOp,
@@ -464,6 +470,7 @@ func (s *Syncer) pushIndex(ctx context.Context, ref name.Repository, pushOp api.
 	// Create and push index
 	idx := &casIndex{
 		syncer:    s,
+		ctx:       ctx,
 		index:     &index,
 		indexData: indexData,
 		pushOp:    pushOp,
@@ -651,6 +658,7 @@ func (s *Syncer) uploadBlob(ctx context.Context, ref name.Repository, desc api.D
 		// on the fly from the .cstream (fetched from CAS) and its input blobs.
 		layer = &compactStreamReconstructingLayer{
 			syncer:    s,
+			ctx:       ctx,
 			digest:    digest,
 			diffID:    desc.DiffID,
 			size:      desc.Size,
@@ -673,6 +681,7 @@ func (s *Syncer) uploadBlob(ctx context.Context, ref name.Repository, desc api.D
 		// Locally-built layer; stream from CAS.
 		layer = &casStreamingLayer{
 			syncer:    s,
+			ctx:       ctx,
 			digest:    digest,
 			diffID:    desc.DiffID,
 			size:      desc.Size,
@@ -784,6 +793,7 @@ func apiDescriptorFromV1(desc v1.Descriptor) api.Descriptor {
 // This type is used when writing single-platform images to registries.
 type casImage struct {
 	syncer       *Syncer
+	ctx          context.Context
 	manifest     *v1.Manifest
 	manifestData []byte
 	pushOp       api.IndexedPushDeployOperation
@@ -806,7 +816,7 @@ func (i *casImage) ConfigName() (v1.Hash, error) {
 
 func (i *casImage) ConfigFile() (*v1.ConfigFile, error) {
 	i.configOnce.Do(func() {
-		configData, err := i.syncer.getBlobFromCAS(context.Background(), apiDescriptorFromV1(i.manifest.Config))
+		configData, err := i.syncer.getBlobFromCAS(i.ctx, apiDescriptorFromV1(i.manifest.Config))
 		if err != nil {
 			i.configErr = err
 			return
@@ -823,7 +833,7 @@ func (i *casImage) ConfigFile() (*v1.ConfigFile, error) {
 }
 
 func (i *casImage) RawConfigFile() ([]byte, error) {
-	return i.syncer.getBlobFromCAS(context.Background(), apiDescriptorFromV1(i.manifest.Config))
+	return i.syncer.getBlobFromCAS(i.ctx, apiDescriptorFromV1(i.manifest.Config))
 }
 
 func (i *casImage) Digest() (v1.Hash, error) {
@@ -904,6 +914,7 @@ func (i *casImage) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
 // This type is used when writing multi-platform image indexes to registries.
 type casIndex struct {
 	syncer    *Syncer
+	ctx       context.Context
 	index     *v1.IndexManifest
 	indexData []byte
 	pushOp    api.IndexedPushDeployOperation
@@ -937,7 +948,7 @@ func (idx *casIndex) RawManifest() ([]byte, error) {
 func (idx *casIndex) Image(hash v1.Hash) (v1.Image, error) {
 	for _, manifest := range idx.index.Manifests {
 		if manifest.Digest == hash {
-			manifestData, err := idx.syncer.getBlobFromCAS(context.Background(), apiDescriptorFromV1(manifest))
+			manifestData, err := idx.syncer.getBlobFromCAS(idx.ctx, apiDescriptorFromV1(manifest))
 			if err != nil {
 				return nil, err
 			}
@@ -949,6 +960,7 @@ func (idx *casIndex) Image(hash v1.Hash) (v1.Image, error) {
 
 			return &casImage{
 				syncer:       idx.syncer,
+				ctx:          idx.ctx,
 				manifest:     &manifestObj,
 				manifestData: manifestData,
 				pushOp:       idx.pushOp,
@@ -1016,6 +1028,7 @@ func (l *casLayer) Uncompressed() (io.ReadCloser, error) {
 // This is used for large blobs (> 1MB) to minimize memory usage during registry uploads.
 type casStreamingLayer struct {
 	syncer    *Syncer
+	ctx       context.Context
 	digest    string
 	diffID    string
 	size      int64
@@ -1078,7 +1091,7 @@ func (l *casStreamingLayer) Compressed() (io.ReadCloser, error) {
 	casDigest := cas.SHA256(hashBytes, l.desc.Size)
 
 	// Get streaming reader from CAS
-	return l.syncer.casClient.ReaderForBlob(context.Background(), casDigest)
+	return l.syncer.casClient.ReaderForBlob(l.ctx, casDigest)
 }
 
 func (l *casStreamingLayer) Uncompressed() (io.ReadCloser, error) {
@@ -1151,6 +1164,7 @@ func (l *remoteStreamingLayer) Uncompressed() (io.ReadCloser, error) {
 // stream from CAS by their digests.
 type compactStreamReconstructingLayer struct {
 	syncer    *Syncer
+	ctx       context.Context
 	digest    string
 	diffID    string
 	size      int64
@@ -1186,7 +1200,7 @@ func (l *compactStreamReconstructingLayer) Compressed() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("compact stream digest %s: %w", l.cstream.Digest, err)
 	}
-	cstreamReader, err := l.syncer.casClient.ReaderForBlob(context.Background(), casDigest)
+	cstreamReader, err := l.syncer.casClient.ReaderForBlob(l.ctx, casDigest)
 	if err != nil {
 		return nil, fmt.Errorf("fetching compact stream %s from CAS: %w", l.cstream.Digest, err)
 	}
@@ -1197,7 +1211,7 @@ func (l *compactStreamReconstructingLayer) Compressed() (io.ReadCloser, error) {
 	pr, pw := io.Pipe()
 	go func() {
 		defer cstreamReader.Close()
-		err := compactstream.Reconstruct(context.Background(), cstreamReader, &casBlobStore{syncer: l.syncer}, pw)
+		err := compactstream.Reconstruct(l.ctx, cstreamReader, &casBlobStore{syncer: l.syncer}, pw)
 		pw.CloseWithError(err)
 	}()
 	return pr, nil

--- a/img_tool/pkg/serve/bes/syncer/syncer.go
+++ b/img_tool/pkg/serve/bes/syncer/syncer.go
@@ -69,7 +69,7 @@ func makeTagKey(ref name.Repository, tag string) string {
 // The syncer maintains thread-safe state across multiple concurrent operations
 // and provides graceful shutdown capabilities.
 type Syncer struct {
-	casClient *cas.CAS
+	casClient casClient
 
 	// Memory cache for small metadata (manifests, configs)
 	metadataCache map[string][]byte
@@ -93,6 +93,12 @@ type Syncer struct {
 	workerCount int
 	shutdown    chan struct{}
 	workerWg    sync.WaitGroup
+}
+
+type casClient interface {
+	ReadBlob(context.Context, cas.Digest) ([]byte, error)
+	ReaderForBlob(context.Context, cas.Digest) (io.ReadCloser, error)
+	ReaderForBlobs(context.Context, []cas.Digest) (io.ReadCloser, error)
 }
 
 // New creates a new Syncer instance with the default worker count of 4.
@@ -412,6 +418,7 @@ func (s *Syncer) pushImage(ctx context.Context, ref name.Repository, pushOp api.
 	// Create and push manifest
 	img := &casImage{
 		syncer:       s,
+		ctx:          ctx,
 		manifest:     &manifest,
 		manifestData: manifestData,
 		pushOp:       pushOp,
@@ -464,6 +471,7 @@ func (s *Syncer) pushIndex(ctx context.Context, ref name.Repository, pushOp api.
 	// Create and push index
 	idx := &casIndex{
 		syncer:    s,
+		ctx:       ctx,
 		index:     &index,
 		indexData: indexData,
 		pushOp:    pushOp,
@@ -651,6 +659,7 @@ func (s *Syncer) uploadBlob(ctx context.Context, ref name.Repository, desc api.D
 		// on the fly from the .cstream (fetched from CAS) and its input blobs.
 		layer = &compactStreamReconstructingLayer{
 			syncer:    s,
+			ctx:       ctx,
 			digest:    digest,
 			diffID:    desc.DiffID,
 			size:      desc.Size,
@@ -673,6 +682,7 @@ func (s *Syncer) uploadBlob(ctx context.Context, ref name.Repository, desc api.D
 		// Locally-built layer; stream from CAS.
 		layer = &casStreamingLayer{
 			syncer:    s,
+			ctx:       ctx,
 			digest:    digest,
 			diffID:    desc.DiffID,
 			size:      desc.Size,
@@ -784,6 +794,7 @@ func apiDescriptorFromV1(desc v1.Descriptor) api.Descriptor {
 // This type is used when writing single-platform images to registries.
 type casImage struct {
 	syncer       *Syncer
+	ctx          context.Context
 	manifest     *v1.Manifest
 	manifestData []byte
 	pushOp       api.IndexedPushDeployOperation
@@ -806,7 +817,7 @@ func (i *casImage) ConfigName() (v1.Hash, error) {
 
 func (i *casImage) ConfigFile() (*v1.ConfigFile, error) {
 	i.configOnce.Do(func() {
-		configData, err := i.syncer.getBlobFromCAS(context.Background(), apiDescriptorFromV1(i.manifest.Config))
+		configData, err := i.syncer.getBlobFromCAS(i.ctx, apiDescriptorFromV1(i.manifest.Config))
 		if err != nil {
 			i.configErr = err
 			return
@@ -823,7 +834,7 @@ func (i *casImage) ConfigFile() (*v1.ConfigFile, error) {
 }
 
 func (i *casImage) RawConfigFile() ([]byte, error) {
-	return i.syncer.getBlobFromCAS(context.Background(), apiDescriptorFromV1(i.manifest.Config))
+	return i.syncer.getBlobFromCAS(i.ctx, apiDescriptorFromV1(i.manifest.Config))
 }
 
 func (i *casImage) Digest() (v1.Hash, error) {
@@ -904,6 +915,7 @@ func (i *casImage) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
 // This type is used when writing multi-platform image indexes to registries.
 type casIndex struct {
 	syncer    *Syncer
+	ctx       context.Context
 	index     *v1.IndexManifest
 	indexData []byte
 	pushOp    api.IndexedPushDeployOperation
@@ -937,7 +949,7 @@ func (idx *casIndex) RawManifest() ([]byte, error) {
 func (idx *casIndex) Image(hash v1.Hash) (v1.Image, error) {
 	for _, manifest := range idx.index.Manifests {
 		if manifest.Digest == hash {
-			manifestData, err := idx.syncer.getBlobFromCAS(context.Background(), apiDescriptorFromV1(manifest))
+			manifestData, err := idx.syncer.getBlobFromCAS(idx.ctx, apiDescriptorFromV1(manifest))
 			if err != nil {
 				return nil, err
 			}
@@ -949,6 +961,7 @@ func (idx *casIndex) Image(hash v1.Hash) (v1.Image, error) {
 
 			return &casImage{
 				syncer:       idx.syncer,
+				ctx:          idx.ctx,
 				manifest:     &manifestObj,
 				manifestData: manifestData,
 				pushOp:       idx.pushOp,
@@ -1016,6 +1029,7 @@ func (l *casLayer) Uncompressed() (io.ReadCloser, error) {
 // This is used for large blobs (> 1MB) to minimize memory usage during registry uploads.
 type casStreamingLayer struct {
 	syncer    *Syncer
+	ctx       context.Context
 	digest    string
 	diffID    string
 	size      int64
@@ -1078,7 +1092,7 @@ func (l *casStreamingLayer) Compressed() (io.ReadCloser, error) {
 	casDigest := cas.SHA256(hashBytes, l.desc.Size)
 
 	// Get streaming reader from CAS
-	return l.syncer.casClient.ReaderForBlob(context.Background(), casDigest)
+	return l.syncer.casClient.ReaderForBlob(l.ctx, casDigest)
 }
 
 func (l *casStreamingLayer) Uncompressed() (io.ReadCloser, error) {
@@ -1151,6 +1165,7 @@ func (l *remoteStreamingLayer) Uncompressed() (io.ReadCloser, error) {
 // stream from CAS by their digests.
 type compactStreamReconstructingLayer struct {
 	syncer    *Syncer
+	ctx       context.Context
 	digest    string
 	diffID    string
 	size      int64
@@ -1186,7 +1201,7 @@ func (l *compactStreamReconstructingLayer) Compressed() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("compact stream digest %s: %w", l.cstream.Digest, err)
 	}
-	cstreamReader, err := l.syncer.casClient.ReaderForBlob(context.Background(), casDigest)
+	cstreamReader, err := l.syncer.casClient.ReaderForBlob(l.ctx, casDigest)
 	if err != nil {
 		return nil, fmt.Errorf("fetching compact stream %s from CAS: %w", l.cstream.Digest, err)
 	}
@@ -1197,7 +1212,7 @@ func (l *compactStreamReconstructingLayer) Compressed() (io.ReadCloser, error) {
 	pr, pw := io.Pipe()
 	go func() {
 		defer cstreamReader.Close()
-		err := compactstream.Reconstruct(context.Background(), cstreamReader, &casBlobStore{syncer: l.syncer}, pw)
+		err := compactstream.Reconstruct(l.ctx, cstreamReader, &casBlobStore{syncer: l.syncer}, pw)
 		pw.CloseWithError(err)
 	}()
 	return pr, nil

--- a/img_tool/pkg/serve/bes/syncer/syncer_test.go
+++ b/img_tool/pkg/serve/bes/syncer/syncer_test.go
@@ -1,0 +1,97 @@
+package syncer
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
+)
+
+type contextRecordingCAS struct {
+	contexts []context.Context
+	data     []byte
+}
+
+func (c *contextRecordingCAS) ReadBlob(ctx context.Context, _ cas.Digest) ([]byte, error) {
+	c.contexts = append(c.contexts, ctx)
+	return append([]byte(nil), c.data...), nil
+}
+
+func (c *contextRecordingCAS) ReaderForBlob(ctx context.Context, _ cas.Digest) (io.ReadCloser, error) {
+	c.contexts = append(c.contexts, ctx)
+	return io.NopCloser(bytes.NewReader(c.data)), nil
+}
+
+func (c *contextRecordingCAS) ReaderForBlobs(ctx context.Context, _ []cas.Digest) (io.ReadCloser, error) {
+	c.contexts = append(c.contexts, ctx)
+	return io.NopCloser(bytes.NewReader(c.data)), nil
+}
+
+func TestLazyCASObjectsPreserveCommitContext(t *testing.T) {
+	ctx := protohelper.WithRequestMetadata(context.Background(), protohelper.RequestMetadata{
+		ToolInvocationID: "invocation",
+		ActionID:         "rules_img:bes:target",
+		ActionMnemonic:   "ImgBESCommit",
+		TargetID:         "//images:app",
+	})
+	digest := v1.Hash{Algorithm: "sha256", Hex: strings.Repeat("a", 64)}
+	descriptor := v1.Descriptor{Digest: digest, Size: 2, MediaType: types.OCIConfigJSON}
+
+	tests := []struct {
+		name string
+		run  func(*Syncer) error
+	}{
+		{
+			name: "image config",
+			run: func(s *Syncer) error {
+				img := &casImage{syncer: s, ctx: ctx, manifest: &v1.Manifest{Config: descriptor}}
+				_, err := img.RawConfigFile()
+				return err
+			},
+		},
+		{
+			name: "index child manifest",
+			run: func(s *Syncer) error {
+				idx := &casIndex{syncer: s, ctx: ctx, index: &v1.IndexManifest{Manifests: []v1.Descriptor{descriptor}}}
+				_, err := idx.Image(digest)
+				return err
+			},
+		},
+		{
+			name: "streaming layer",
+			run: func(s *Syncer) error {
+				layer := &casStreamingLayer{syncer: s, ctx: ctx, desc: api.Descriptor{Digest: "sha256:" + strings.Repeat("a", 64), Size: 2}}
+				r, err := layer.Compressed()
+				if err == nil {
+					err = r.Close()
+				}
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := &contextRecordingCAS{data: []byte("{}")}
+			s := &Syncer{casClient: recorder, metadataCache: make(map[string][]byte)}
+			if err := tc.run(s); err != nil {
+				t.Fatal(err)
+			}
+			if len(recorder.contexts) != 1 {
+				t.Fatalf("CAS received %d contexts, want 1", len(recorder.contexts))
+			}
+			got, ok := protohelper.RequestMetadataFromContext(recorder.contexts[0])
+			if !ok || got.ToolInvocationID != "invocation" || got.ActionID != "rules_img:bes:target" {
+				t.Errorf("CAS request metadata = %+v, present=%v", got, ok)
+			}
+		})
+	}
+}

--- a/img_tool/pkg/serve/bes/syncer/syncer_test.go
+++ b/img_tool/pkg/serve/bes/syncer/syncer_test.go
@@ -1,0 +1,92 @@
+package syncer
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
+)
+
+type contextRecordingCAS struct {
+	contexts []context.Context
+	data     []byte
+}
+
+func (c *contextRecordingCAS) ReadBlob(ctx context.Context, _ cas.Digest) ([]byte, error) {
+	c.contexts = append(c.contexts, ctx)
+	return append([]byte(nil), c.data...), nil
+}
+
+func (c *contextRecordingCAS) ReaderForBlob(ctx context.Context, _ cas.Digest) (io.ReadCloser, error) {
+	c.contexts = append(c.contexts, ctx)
+	return io.NopCloser(bytes.NewReader(c.data)), nil
+}
+
+func TestLazyCASObjectsPreserveCommitContext(t *testing.T) {
+	ctx := protohelper.WithRequestMetadata(context.Background(), protohelper.RequestMetadata{
+		ToolInvocationID: "invocation",
+		ActionID:         "rules_img:bes:target",
+		ActionMnemonic:   "ImgBESCommit",
+		TargetID:         "//images:app",
+	})
+	digest := v1.Hash{Algorithm: "sha256", Hex: strings.Repeat("a", 64)}
+	descriptor := v1.Descriptor{Digest: digest, Size: 2, MediaType: types.OCIConfigJSON}
+
+	tests := []struct {
+		name string
+		run  func(*Syncer) error
+	}{
+		{
+			name: "image config",
+			run: func(s *Syncer) error {
+				img := &casImage{syncer: s, ctx: ctx, manifest: &v1.Manifest{Config: descriptor}}
+				_, err := img.RawConfigFile()
+				return err
+			},
+		},
+		{
+			name: "index child manifest",
+			run: func(s *Syncer) error {
+				idx := &casIndex{syncer: s, ctx: ctx, index: &v1.IndexManifest{Manifests: []v1.Descriptor{descriptor}}}
+				_, err := idx.Image(digest)
+				return err
+			},
+		},
+		{
+			name: "streaming layer",
+			run: func(s *Syncer) error {
+				layer := &casStreamingLayer{syncer: s, ctx: ctx, desc: api.Descriptor{Digest: "sha256:" + strings.Repeat("a", 64), Size: 2}}
+				r, err := layer.Compressed()
+				if err == nil {
+					err = r.Close()
+				}
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := &contextRecordingCAS{data: []byte("{}")}
+			s := &Syncer{casClient: recorder, metadataCache: make(map[string][]byte)}
+			if err := tc.run(s); err != nil {
+				t.Fatal(err)
+			}
+			if len(recorder.contexts) != 1 {
+				t.Fatalf("CAS received %d contexts, want 1", len(recorder.contexts))
+			}
+			got, ok := protohelper.RequestMetadataFromContext(recorder.contexts[0])
+			if !ok || got.ToolInvocationID != "invocation" || got.ActionID != "rules_img:bes:target" {
+				t.Errorf("CAS request metadata = %+v, present=%v", got, ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
rules_img cache requests currently omit the invocation and action metadata that BuildBuddy uses for its Cache Requests card. Users can see aggregate cache traffic, but cannot associate CAS and ByteStream transfers with the image operation that caused them. This leaves cache debugging without the request-level evidence needed to explain image behavior. This matters because the card is the only per-request view of cache transfers associated with an invocation.

Teach `img` to accept an invocation ID, default `bazel run` executions from `BUILD_ID`, and pass per-request IDs through deploy workers. Merge this data with caller metadata in one header for unary and streaming RPCs, including blob-cache proxy hops.

Carry operation metadata through lazy deploy and BES reads and ByteStream retries. BES commits use authoritative stream invocation IDs and stable target-completion action IDs. Keep the tool identity as `rules_img`; BuildBuddy attribution uses `tool_invocation_id` and does not require a `bazel` tool name.

Add focused coverage for metadata merging, worker parsing, BES commit contexts, lazy reads, and reconnect retries. A real BuildBuddy capture showing the resulting `ImgDeploy` CAS hits is attached in the PR conversation.
