### PR TITLE
fix(compactstream): prefetch small CAS blobs concurrently

### DIFF
--- a/img_tool/pkg/compactstream/reader.go
+++ b/img_tool/pkg/compactstream/reader.go
@@ -16,6 +16,31 @@ type BlobStore interface {
 	ReaderForBlob(ctx context.Context, digest []byte, size int64) (io.ReadCloser, error)
 }
 
+// BlobRequest identifies one content-addressed blob needed to reconstruct a
+// compact stream.
+type BlobRequest struct {
+	Digest []byte
+	Size   int64
+}
+
+// BatchBlobStore can fetch several small blobs concurrently. Results must
+// correspond to requests by index and contain exactly the requested bytes.
+// Reconstruct falls back to BlobStore for stores that do not implement this
+// optional interface and for blobs too large to buffer.
+type BatchBlobStore interface {
+	BlobStore
+	ReadBlobs(ctx context.Context, requests []BlobRequest) ([][]byte, error)
+}
+
+const (
+	// These limits cover a high-latency 1 Gbit/s link without letting one layer
+	// retain an unbounded amount of prefetched data. The per-blob limit matches
+	// the default REAPI BatchReadBlobs limit used by pkg/cas.
+	maxBatchBlobSize = 2 << 20
+	maxBatchBytes    = 16 << 20
+	maxBatchBlobs    = 64
+)
+
 func Reconstruct(ctx context.Context, index io.Reader, store BlobStore, output io.Writer) error {
 	header, err := ReadHeader(index)
 	if err != nil {
@@ -331,17 +356,46 @@ func (zeroReader) Read(p []byte) (int, error) {
 // materializes the whole tar.
 func writeReconstructed(ctx context.Context, dst io.Writer, stream io.Reader, refs []CASReference, store BlobStore) error {
 	var outputPos uint64
-	for _, r := range refs {
+	batchStore, canBatch := store.(BatchBlobStore)
+	for refIndex := 0; refIndex < len(refs); {
+		if canBatch {
+			batchEnd := blobBatchEnd(refs, refIndex)
+			if batchEnd > refIndex {
+				requests := make([]BlobRequest, batchEnd-refIndex)
+				for i, ref := range refs[refIndex:batchEnd] {
+					requests[i] = BlobRequest{Digest: ref.Digest, Size: int64(ref.Size)}
+				}
+				blobs, err := batchStore.ReadBlobs(ctx, requests)
+				if err != nil {
+					return fmt.Errorf("fetching blob batch at offset %d: %w", refs[refIndex].Offset, err)
+				}
+				if len(blobs) != len(requests) {
+					return fmt.Errorf("fetching blob batch at offset %d: got %d blobs, expected %d", refs[refIndex].Offset, len(blobs), len(requests))
+				}
+				for i, blob := range blobs {
+					ref := refs[refIndex+i]
+					if uint64(len(blob)) != ref.Size {
+						return fmt.Errorf("blob at offset %d has size %d, expected %d", ref.Offset, len(blob), ref.Size)
+					}
+					if err := writeGap(dst, stream, &outputPos, ref.Offset); err != nil {
+						return err
+					}
+					if _, err := io.Copy(dst, bytes.NewReader(blob)); err != nil {
+						return fmt.Errorf("writing blob at offset %d: %w", ref.Offset, err)
+					}
+					outputPos = ref.Offset + ref.Size
+				}
+				refIndex = batchEnd
+				continue
+			}
+		}
+
+		r := refs[refIndex]
 		// readRefTable already rejects unsorted/overlapping refs; this guard is
 		// belt-and-suspenders so the unsigned subtraction below can never
 		// underflow into a negative int64 copy count.
-		if r.Offset < outputPos {
-			return fmt.Errorf("CAS ref offset %d precedes current output position %d (unsorted or overlapping ref table)", r.Offset, outputPos)
-		}
-		if gap := r.Offset - outputPos; gap > 0 {
-			if _, err := io.CopyN(dst, stream, int64(gap)); err != nil {
-				return fmt.Errorf("copying stream bytes at offset %d (gap %d): %w", outputPos, gap, err)
-			}
+		if err := writeGap(dst, stream, &outputPos, r.Offset); err != nil {
+			return err
 		}
 
 		blobReader, err := store.ReaderForBlob(ctx, r.Digest, int64(r.Size))
@@ -355,11 +409,41 @@ func writeReconstructed(ctx context.Context, dst io.Writer, stream io.Reader, re
 		blobReader.Close()
 
 		outputPos = r.Offset + r.Size
+		refIndex++
 	}
 
 	if _, err := io.Copy(dst, stream); err != nil {
 		return fmt.Errorf("copying remaining stream bytes: %w", err)
 	}
+	return nil
+}
+
+func blobBatchEnd(refs []CASReference, start int) int {
+	var total uint64
+	end := start
+	for end < len(refs) && end-start < maxBatchBlobs {
+		size := refs[end].Size
+		if size > maxBatchBlobSize || total+size > maxBatchBytes {
+			break
+		}
+		total += size
+		end++
+	}
+	return end
+}
+
+func writeGap(dst io.Writer, stream io.Reader, outputPos *uint64, nextOffset uint64) error {
+	if nextOffset < *outputPos {
+		return fmt.Errorf("CAS ref offset %d precedes current output position %d (unsorted or overlapping ref table)", nextOffset, *outputPos)
+	}
+	gap := nextOffset - *outputPos
+	if gap == 0 {
+		return nil
+	}
+	if _, err := io.CopyN(dst, stream, int64(gap)); err != nil {
+		return fmt.Errorf("copying stream bytes at offset %d (gap %d): %w", *outputPos, gap, err)
+	}
+	*outputPos = nextOffset
 	return nil
 }
 

--- a/img_tool/pkg/compactstream/reader_test.go
+++ b/img_tool/pkg/compactstream/reader_test.go
@@ -72,6 +72,30 @@ func (m mapBlobStore) ReaderForBlob(_ context.Context, digest []byte, _ int64) (
 	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
+type batchMapBlobStore struct {
+	blobs       mapBlobStore
+	batchSizes  []int
+	serialReads int
+}
+
+func (s *batchMapBlobStore) ReaderForBlob(ctx context.Context, digest []byte, size int64) (io.ReadCloser, error) {
+	s.serialReads++
+	return s.blobs.ReaderForBlob(ctx, digest, size)
+}
+
+func (s *batchMapBlobStore) ReadBlobs(_ context.Context, requests []BlobRequest) ([][]byte, error) {
+	s.batchSizes = append(s.batchSizes, len(requests))
+	blobs := make([][]byte, len(requests))
+	for i, request := range requests {
+		blob, ok := s.blobs[string(request.Digest)]
+		if !ok {
+			return nil, fmt.Errorf("blob not found: %x", request.Digest)
+		}
+		blobs[i] = blob
+	}
+	return blobs, nil
+}
+
 func validEmptyIndex(t *testing.T) []byte {
 	t.Helper()
 	var buf bytes.Buffer
@@ -182,6 +206,62 @@ func TestReconstructInterleavesGapsAndBlobs(t *testing.T) {
 	}
 	if got, want := out.String(), "HDR-BLOBDATA-END"; got != want {
 		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestReconstructReadsSmallBlobsInBoundedBatches(t *testing.T) {
+	store := &batchMapBlobStore{blobs: mapBlobStore{}}
+	var refs []rawRef
+	var stream, want []byte
+	var offset uint64
+	for i := range 130 {
+		gap := []byte{byte(i)}
+		blob := bytes.Repeat([]byte{byte(i), byte(i >> 8)}, 512)
+		digest := store.blobs.put(blob)
+		stream = append(stream, gap...)
+		want = append(want, gap...)
+		offset += uint64(len(gap))
+		refs = append(refs, rawRef{offset: offset, digest: digest, size: uint64(len(blob))})
+		want = append(want, blob...)
+		offset += uint64(len(blob))
+	}
+
+	idx := buildRawCompactStream(refs, stream)
+	var out bytes.Buffer
+	if err := Reconstruct(context.Background(), bytes.NewReader(idx), store, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(out.Bytes(), want) {
+		t.Fatal("batched reconstruction changed the output")
+	}
+	if got, want := fmt.Sprint(store.batchSizes), "[64 64 2]"; got != want {
+		t.Fatalf("batch sizes = %s, want %s", got, want)
+	}
+	if store.serialReads != 0 {
+		t.Fatalf("small blobs were read serially %d times", store.serialReads)
+	}
+}
+
+func TestBlobBatchEndHonorsLimits(t *testing.T) {
+	countLimited := make([]CASReference, maxBatchBlobs+1)
+	for i := range countLimited {
+		countLimited[i].Size = 1
+	}
+	if got := blobBatchEnd(countLimited, 0); got != maxBatchBlobs {
+		t.Fatalf("count-limited batch ended at %d, want %d", got, maxBatchBlobs)
+	}
+
+	byteLimited := make([]CASReference, 10)
+	for i := range byteLimited {
+		byteLimited[i].Size = maxBatchBlobSize
+	}
+	if got := blobBatchEnd(byteLimited, 0); got != maxBatchBytes/maxBatchBlobSize {
+		t.Fatalf("byte-limited batch ended at %d, want %d", got, maxBatchBytes/maxBatchBlobSize)
+	}
+
+	tooLarge := []CASReference{{Size: maxBatchBlobSize + 1}}
+	if got := blobBatchEnd(tooLarge, 0); got != 0 {
+		t.Fatalf("oversized blob was included in a batch ending at %d", got)
 	}
 }
 

--- a/img_tool/pkg/deployvfs/BUILD.bazel
+++ b/img_tool/pkg/deployvfs/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/types",
+        "@org_golang_x_sync//errgroup",
         "@rules_go//go/runfiles",
     ],
 )

--- a/img_tool/pkg/deployvfs/compactstream.go
+++ b/img_tool/pkg/deployvfs/compactstream.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/compactstream"
+	"golang.org/x/sync/errgroup"
 )
 
 // WithCompactStreamLayer registers a .cstream index file that reconstructs the
@@ -243,6 +244,8 @@ type casDirStore struct {
 	casReader     casReader
 }
 
+var _ compactstream.BatchBlobStore = (*casDirStore)(nil)
+
 func (s *casDirStore) ReaderForBlob(ctx context.Context, digest []byte, size int64) (io.ReadCloser, error) {
 	hexDigest := hex.EncodeToString(digest)
 
@@ -273,4 +276,38 @@ func (s *casDirStore) ReaderForBlob(ctx context.Context, digest []byte, size int
 	}
 
 	return nil, fmt.Errorf("blob sha256:%s (size %d) not found in input file CAS directory, disk cache, or remote cache", hexDigest, size)
+}
+
+// ReadBlobs fetches a bounded compact-stream batch concurrently. Reconstruct
+// caps batches at 64 blobs and 16 MiB, so reading each result into memory here
+// remains bounded while allowing high-latency CAS requests to overlap.
+func (s *casDirStore) ReadBlobs(ctx context.Context, requests []compactstream.BlobRequest) ([][]byte, error) {
+	blobs := make([][]byte, len(requests))
+	g, groupCtx := errgroup.WithContext(ctx)
+	for i, request := range requests {
+		i, request := i, request
+		g.Go(func() error {
+			reader, err := s.ReaderForBlob(groupCtx, request.Digest, request.Size)
+			if err != nil {
+				return err
+			}
+			blob, readErr := io.ReadAll(io.LimitReader(reader, request.Size+1))
+			closeErr := reader.Close()
+			if readErr != nil {
+				return readErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+			if int64(len(blob)) != request.Size {
+				return fmt.Errorf("blob sha256:%s has size %d, expected %d", hex.EncodeToString(request.Digest), len(blob), request.Size)
+			}
+			blobs[i] = blob
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return blobs, nil
 }

--- a/img_tool/pkg/deployvfs/compactstream_test.go
+++ b/img_tool/pkg/deployvfs/compactstream_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
@@ -20,6 +21,43 @@ import (
 
 type stubCASReader struct {
 	blobs map[string][]byte // keyed by hex(digest.Hash)
+}
+
+type blockingCASReader struct {
+	blobs   map[string][]byte
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingCASReader) FindMissingBlobs(context.Context, []cas.Digest) ([]cas.Digest, error) {
+	return nil, nil
+}
+
+func (s *blockingCASReader) ReadBlob(ctx context.Context, d cas.Digest) ([]byte, error) {
+	reader, err := s.ReaderForBlob(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	return io.ReadAll(reader)
+}
+
+func (s *blockingCASReader) ReaderForBlob(ctx context.Context, d cas.Digest) (io.ReadCloser, error) {
+	select {
+	case s.started <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	b, ok := s.blobs[hex.EncodeToString(d.Hash)]
+	if !ok {
+		return nil, fmt.Errorf("blob not found")
+	}
+	return io.NopCloser(bytes.NewReader(b)), nil
 }
 
 func (s *stubCASReader) FindMissingBlobs(context.Context, []cas.Digest) ([]cas.Digest, error) {
@@ -77,6 +115,59 @@ func TestCasDirStoreInputDirHit(t *testing.T) {
 	}
 	if got := readAllClose(t, rc); !bytes.Equal(got, content) {
 		t.Fatalf("got %q, want %q", got, content)
+	}
+}
+
+func TestCasDirStoreReadsBatchConcurrently(t *testing.T) {
+	const blobCount = 8
+	remote := &blockingCASReader{
+		blobs:   make(map[string][]byte, blobCount),
+		started: make(chan struct{}, blobCount),
+		release: make(chan struct{}),
+	}
+	released := false
+	defer func() {
+		if !released {
+			close(remote.release)
+		}
+	}()
+
+	requests := make([]compactstream.BlobRequest, blobCount)
+	for i := range blobCount {
+		blob := []byte(fmt.Sprintf("blob-%d", i))
+		digest := sha256.Sum256(blob)
+		remote.blobs[hex.EncodeToString(digest[:])] = blob
+		requests[i] = compactstream.BlobRequest{Digest: digest[:], Size: int64(len(blob))}
+	}
+
+	type result struct {
+		blobs [][]byte
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		blobs, err := (&casDirStore{casReader: remote}).ReadBlobs(context.Background(), requests)
+		done <- result{blobs: blobs, err: err}
+	}()
+
+	for range blobCount {
+		select {
+		case <-remote.started:
+		case <-time.After(time.Second):
+			t.Fatal("blob reads did not run concurrently")
+		}
+	}
+	close(remote.release)
+	released = true
+
+	got := <-done
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	for i, blob := range got.blobs {
+		if want := fmt.Sprintf("blob-%d", i); string(blob) != want {
+			t.Fatalf("blob %d = %q, want %q", i, blob, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Motivation

Compact streams replace file contents with CAS references, but reconstruction read each reference synchronously. Most file blobs fit in a unary `BatchReadBlobs` request, so a high-latency remote cache paid one round trip per file. This also left the connection pool added in #623 mostly idle.

In one representative layer, nearly 7,000 small references averaged about 38 KiB. At roughly 23 ms RTT, reconstruction managed only 1-2 MiB/s while a single large CAS read over the same route exceeded 60 MiB/s.

## Approach

Add optional bounded prefetch support to compact-stream blob stores. `casDirStore` fetches windows concurrently through the existing CAS reader and connection pool, then writes the blobs in their original order. Windows are capped at 64 blobs and 16 MiB, keeping memory use bounded. Blobs larger than 2 MiB and stores without prefetch support retain the existing streaming path.

The tests verify output equivalence, batching limits, concurrent reads, and result ordering.

## Testing

- `bazel test //pkg/compactstream:compactstream_test //pkg/deployvfs:deployvfs_test` from the `img_tool` module
- `bazel build //cmd/img:img` from the `img_tool` module

Generated with [Codex](https://openai.com/codex/).