### PR TITLE
feat: add support for wasm32 architecture

### DIFF
--- a/img/private/config/BUILD.bazel
+++ b/img/private/config/BUILD.bazel
@@ -11,6 +11,7 @@ os_cpu(
         "@platforms//cpu:ppc64le": "ppc64le",
         "@platforms//cpu:riscv64": "riscv64",
         "@platforms//cpu:s390x": "s390x",
+        "@platforms//cpu:wasm32": "wasm",
         "@platforms//cpu:x86_32": "386",
         "@platforms//cpu:x86_64": "amd64",
     }),


### PR DESCRIPTION
Adds support for wasm32 architecture, making it possible to target wasip1_wasm32 (e.g. Proxy-Wasm plugins distributed as OCI images).

The chosen value (`wasm`) conforms to OCI spec / GOARCH values for wasm32: https://go.dev/doc/install/source#environment

`wasip1` is already supported value for OS by `rules_img`, so CPU architecture was the only missing bit.