### PR TITLE
fix(cas): raise the gRPC receive limit and reserve batch framing headroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ linux/arm64).
 - [Platforms Guide](docs/platforms.md) - Working with Bazel platforms, architecture variants, and multi-platform builds
 - [Image Signing Guide](docs/image-signing.md) - Sign pushed images with pluggable signer plugins (Notation, cosign, or your own)
 - [Push Strategies](docs/push-strategies.md) - Push strategies and [push at build time](docs/push-strategies.md#push-at-build-time)
-- [Remote Cache Reliability](docs/remote-cache.md) - How the `img` tool talks to Bazel's remote cache: retries, timeouts, connection pooling and resumable transfers
+- [Remote Cache Reliability](docs/remote-cache.md) - How the `img` tool talks to Bazel's remote cache: retries, timeouts, message sizes, connection pooling and resumable transfers
 - [Registry Support Matrix](docs/registry-support.md) - Which registries mount blobs across repositories, serve OCI 1.1 referrers, or share blobs on their own — and which features need what
 - [Authenticating Build Actions](docs/authenticating-build-actions.md) - Registry credentials for build-time pull/push, and the OCI distribution gateway
 - [Insecure (Plain-HTTP) Registries](docs/insecure-registries.md) - Push to a local development registry that speaks HTTP or has an untrusted certificate

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -55,6 +55,34 @@ of blocking the deploy forever.
 Uploads are deliberately left without an idle limit: unlike a read, a write
 cannot be resumed for free.
 
+## Message size
+
+Every connection the `img` tool opens to the remote cache accepts gRPC messages up
+to 100 MiB, above grpc-go's own 4 MiB default. Without that, an ordinary blob read
+can fail:
+
+```
+rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4194309 vs. 4194304)
+```
+
+The remote execution API places no bound on the size of a `ReadResponse`, and
+`GetCapabilities` exposes no field from which a client could derive one, so a server
+is free to divide a blob into whatever chunks it likes, and is within spec when it
+does. Bazel raises the same limit to `Integer.MAX_VALUE`; 100 MiB is the figure
+`bazelbuild/remote-apis-sdks` uses.
+
+Treat 100 MiB as a compromise rather than a safety bound. It applies per call, and
+`img deploy` pools one connection per job, so reads in flight together can hold a
+multiple of it.
+
+| Variable | Effect |
+|----------|--------|
+| `IMG_REAPI_MAX_RECV_MSG_SIZE` | Largest gRPC message the tool will accept, in bytes (default `104857600`, 100 MiB). Values below grpc-go's own 4 MiB default are ignored with a warning |
+
+The limit covers every call on those connections, including to the
+[local blob cache](push-strategies.md#local-blob-cache) endpoint, which is not a
+remote execution API service despite the variable's `IMG_REAPI_` prefix.
+
 ## Connection pooling
 
 A single gRPC connection multiplexes every request onto one TCP connection, which

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -83,6 +83,31 @@ The limit covers every call on those connections, including to the
 [local blob cache](push-strategies.md#local-blob-cache) endpoint, which is not a
 remote execution API service despite the variable's `IMG_REAPI_` prefix.
 
+### Batch requests
+
+Blobs small enough to batch are read and written with `BatchReadBlobs` and
+`BatchUpdateBlobs` instead of being streamed. `max_batch_total_size_bytes` from
+`GetCapabilities` says how large a batch the server accepts.
+
+That figure bounds the blob payload rather than the serialized message: the
+specification calls it the "maximum total size of blobs" and names the message size
+limit of the transport as a separate constraint. A request for exactly the declared
+limit is therefore within the server's stated budget, yet once per-blob digest,
+status and length-delimiter fields are added the message is over it. 4 MiB is the
+default limit for what a gRPC server will accept, so the server refuses the request.
+
+`img` holds back 1 KiB of the budget for framing, subtracted from whichever limit is
+lower: what the server declares, or the 4 MiB it assumes of the transport. A server
+declaring less than 4 MiB gets the same treatment, because it may be enforcing a
+lower transport limit to match.
+
+This matters on the upload path, for `BatchUpdateBlobs` and for the chunks a streamed
+upload sends: the client's own receive limit does nothing about a message the server
+will not accept.
+
+`img deploy` does not ask the server for its capabilities and uses a fixed 2 MiB
+budget regardless. The figures above apply to the BES and CAS registry paths.
+
 ## Connection pooling
 
 A single gRPC connection multiplexes every request onto one TCP connection, which

--- a/img_tool/pkg/auth/protohelper/BUILD.bazel
+++ b/img_tool/pkg/auth/protohelper/BUILD.bazel
@@ -17,9 +17,15 @@ go_library(
 
 go_test(
     name = "protohelper_test",
+    size = "small",
     srcs = ["protohelper_test.go"],
     embed = [":protohelper"],
     deps = [
         "//pkg/auth/credential",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/img_tool/pkg/auth/protohelper/protohelper.go
+++ b/img_tool/pkg/auth/protohelper/protohelper.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"slices"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,8 +20,49 @@ import (
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/grpcheaderinterceptor"
 )
 
+// EnvMaxRecvMsgSize overrides, in bytes, the largest gRPC message the clients built here
+// will accept. It follows the IMG_REAPI_* convention of pkg/cas, though it reaches every
+// connection [Client] builds, including the blob cache endpoint, which is not a remote
+// execution API service.
+const EnvMaxRecvMsgSize = "IMG_REAPI_MAX_RECV_MSG_SIZE"
+
+// defaultMaxRecvMsgSize has to exceed grpc-go's own 4 MiB, because the remote execution
+// API bounds ReadResponse size nowhere and GetCapabilities exposes no field to derive a
+// bound from: a conforming server may answer an ordinary whole-blob read with a larger
+// message. 100 MiB is bazelbuild/remote-apis-sdks' figure, kept finite even though the
+// limit is per call and a deploy pools one connection per job, so concurrent allocation
+// can reach this times the job count. Bazel keeps no ceiling at all
+// (maxInboundMessageSize(Integer.MAX_VALUE)).
+const defaultMaxRecvMsgSize = 100 * 1024 * 1024
+
+// minMaxRecvMsgSize is the floor for EnvMaxRecvMsgSize, and grpc-go's own default. Below
+// it, reads an unconfigured client would have completed fail instead, and pkg/cas spends a
+// full retry budget per blob on the ResourceExhausted before reporting anything.
+const minMaxRecvMsgSize = 4 * 1024 * 1024
+
+// maxRecvMsgSize is the environment-derived limit [Client] applies, parsed once: a deploy
+// builds one client per pooled connection, and a malformed value is worth one warning.
+var maxRecvMsgSize = sync.OnceValue(maxRecvMsgSizeFromEnv)
+
+func maxRecvMsgSizeFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv(EnvMaxRecvMsgSize))
+	if raw == "" {
+		return defaultMaxRecvMsgSize
+	}
+	size, err := strconv.Atoi(raw)
+	if err != nil || size < minMaxRecvMsgSize {
+		warnInvalidEnv(EnvMaxRecvMsgSize, raw, defaultMaxRecvMsgSize)
+		return defaultMaxRecvMsgSize
+	}
+	return size
+}
+
 func Client(uri string, helper credhelper.Helper, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	opts = slices.Clone(opts)
+	// Ours goes first so a caller passing its own MaxCallRecvMsgSize wins: grpc
+	// applies call options in order and the last one set takes effect.
+	opts = append([]grpc.DialOption{
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxRecvMsgSize())),
+	}, opts...)
 
 	parsed, err := url.Parse(uri)
 	if err != nil {
@@ -119,7 +161,12 @@ func warnUnencryptedGRPC(uri string) {
 		return
 	}
 	WarnedURIs[uri] = struct{}{}
-	fmt.Fprintf(os.Stderr, "WARNING: using unencrypted grpc connection to %s - please consider using grpcs instead", uri)
+	fmt.Fprintf(os.Stderr, "WARNING: using unencrypted grpc connection to %s - please consider using grpcs instead\n", uri)
+}
+
+// warnInvalidEnv is duplicated from pkg/cas, where the same helper is unexported.
+func warnInvalidEnv(name, raw string, fallback any) {
+	fmt.Fprintf(os.Stderr, "WARNING: ignoring invalid %s=%q, using %v\n", name, raw, fallback)
 }
 
 // WarnedURIs is a set of URIs that have already been warned about.

--- a/img_tool/pkg/auth/protohelper/protohelper_test.go
+++ b/img_tool/pkg/auth/protohelper/protohelper_test.go
@@ -2,8 +2,17 @@ package protohelper
 
 import (
 	"context"
+	"net"
 	"net/url"
+	"os"
+	"strings"
 	"testing"
+
+	bytestream_proto "google.golang.org/genproto/googleapis/bytestream"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/credential"
 )
@@ -209,4 +218,214 @@ func TestClientTarget(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMaxRecvMsgSizeFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		unset    bool
+		want     int
+		wantWarn bool
+	}{
+		{
+			name:  "unset",
+			unset: true,
+			want:  defaultMaxRecvMsgSize,
+		},
+		{
+			name:  "empty",
+			value: "",
+			want:  defaultMaxRecvMsgSize,
+		},
+		{
+			name:  "valid size",
+			value: "8388608",
+			want:  8388608,
+		},
+		{
+			name:  "surrounding whitespace",
+			value: "  8388608  ",
+			want:  8388608,
+		},
+		{
+			// The floor itself is honored: it is what grpc-go would have applied anyway.
+			name:  "exactly the floor",
+			value: "4194304",
+			want:  minMaxRecvMsgSize,
+		},
+		{
+			name:     "unparseable",
+			value:    "lots",
+			want:     defaultMaxRecvMsgSize,
+			wantWarn: true,
+		},
+		{
+			name:     "zero",
+			value:    "0",
+			want:     defaultMaxRecvMsgSize,
+			wantWarn: true,
+		},
+		{
+			name:     "negative",
+			value:    "-1",
+			want:     defaultMaxRecvMsgSize,
+			wantWarn: true,
+		},
+		{
+			name:     "below the floor",
+			value:    "1024",
+			want:     defaultMaxRecvMsgSize,
+			wantWarn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv registers the restore, so unsetting after it exercises a
+			// genuinely absent variable and still leaves the environment clean.
+			t.Setenv(EnvMaxRecvMsgSize, tt.value)
+			if tt.unset {
+				if err := os.Unsetenv(EnvMaxRecvMsgSize); err != nil {
+					t.Fatalf("unsetting %s: %v", EnvMaxRecvMsgSize, err)
+				}
+			}
+			stderr := captureStderr(t)
+
+			// Not the sync.OnceValue wrapper: it would parse the environment once for
+			// the whole test binary.
+			if got := maxRecvMsgSizeFromEnv(); got != tt.want {
+				t.Errorf("maxRecvMsgSizeFromEnv() = %d, want %d", got, tt.want)
+			}
+
+			warned := strings.Contains(stderr.String(), EnvMaxRecvMsgSize)
+			if warned != tt.wantWarn {
+				t.Errorf("warned = %v, want %v (stderr: %q)", warned, tt.wantWarn, stderr.String())
+			}
+		})
+	}
+}
+
+// bigReadResponseServer answers any ByteStream.Read with a single response of a fixed
+// size, leaving the client's receive limit as the only thing deciding whether it succeeds.
+type bigReadResponseServer struct {
+	bytestream_proto.UnimplementedByteStreamServer
+	payload []byte
+}
+
+func (s *bigReadResponseServer) Read(_ *bytestream_proto.ReadRequest, stream bytestream_proto.ByteStream_ReadServer) error {
+	return stream.Send(&bytestream_proto.ReadResponse{Data: s.payload})
+}
+
+func serveBigReadResponses(t *testing.T, payloadSize int) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listening on loopback: %v", err)
+	}
+	server := grpc.NewServer()
+	bytestream_proto.RegisterByteStreamServer(server, &bigReadResponseServer{payload: make([]byte, payloadSize)})
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(server.Stop)
+	return listener.Addr().String()
+}
+
+// readOneResponse reports the size of the first ReadResponse, not of the whole blob.
+func readOneResponse(conn *grpc.ClientConn) (int, error) {
+	stream, err := bytestream_proto.NewByteStreamClient(conn).Read(
+		context.Background(),
+		&bytestream_proto.ReadRequest{ResourceName: "blobs/test/1"},
+	)
+	if err != nil {
+		return 0, err
+	}
+	response, err := stream.Recv()
+	if err != nil {
+		return 0, err
+	}
+	return len(response.Data), nil
+}
+
+// TestClientAcceptsLargeResponses covers the dial option itself, which the parsing test
+// above does not reach.
+func TestClientAcceptsLargeResponses(t *testing.T) {
+	// Above grpc-go's 4 MiB default, and above the 4194309-byte response in #720.
+	const payloadSize = 5 * 1024 * 1024
+	address := serveBigReadResponses(t, payloadSize)
+
+	t.Run("Client raises the limit", func(t *testing.T) {
+		conn, err := Client("grpc://"+address, credential.NopHelper())
+		if err != nil {
+			t.Fatalf("Client returned error: %v", err)
+		}
+		defer conn.Close()
+
+		got, err := readOneResponse(conn)
+		if err != nil {
+			t.Fatalf("reading a %d byte response: %v", payloadSize, err)
+		}
+		if got != payloadSize {
+			t.Errorf("received %d bytes, want %d", got, payloadSize)
+		}
+	})
+
+	t.Run("an unconfigured connection does not", func(t *testing.T) {
+		// Confirms the server really does send something a default client rejects, so
+		// the case above is not passing for an unrelated reason.
+		conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			t.Fatalf("grpc.NewClient returned error: %v", err)
+		}
+		defer conn.Close()
+
+		if _, err := readOneResponse(conn); status.Code(err) != codes.ResourceExhausted {
+			t.Fatalf("error = %v (code %s), want %s", err, status.Code(err), codes.ResourceExhausted)
+		}
+	})
+
+	t.Run("a caller's own limit still wins", func(t *testing.T) {
+		// The dial option in [Client] is prepended so this holds.
+		conn, err := Client("grpc://"+address, credential.NopHelper(),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024)))
+		if err != nil {
+			t.Fatalf("Client returned error: %v", err)
+		}
+		defer conn.Close()
+
+		if _, err := readOneResponse(conn); status.Code(err) != codes.ResourceExhausted {
+			t.Fatalf("error = %v (code %s), want %s", err, status.Code(err), codes.ResourceExhausted)
+		}
+	})
+}
+
+// captureStderr redirects stderr to a file for the duration of the test. It swaps the
+// process-wide os.Stderr, so no test in this package may call t.Parallel while holding one.
+func captureStderr(t *testing.T) *stderrCapture {
+	t.Helper()
+	file, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatalf("creating stderr capture file: %v", err)
+	}
+	previousStderr := os.Stderr
+	t.Cleanup(func() {
+		os.Stderr = previousStderr
+		file.Close()
+	})
+
+	os.Stderr = file
+	return &stderrCapture{t: t, file: file}
+}
+
+type stderrCapture struct {
+	t    *testing.T
+	file *os.File
+}
+
+func (c *stderrCapture) String() string {
+	c.t.Helper()
+	data, err := os.ReadFile(c.file.Name())
+	if err != nil {
+		c.t.Fatalf("reading stderr capture: %v", err)
+	}
+	return string(data)
 }

--- a/img_tool/pkg/cas/read.go
+++ b/img_tool/pkg/cas/read.go
@@ -309,6 +309,29 @@ func (d Digest) protoDigestFunction() remoteexecution_proto.DigestFunction_Value
 	}
 }
 
+// max_batch_total_size_bytes limits blob payload, not the serialized message: the spec
+// calls it the "maximum total size of blobs" and names the transport's message limit
+// separately, and Buildbarn enforces it that way, counting only digest sizes. So a
+// request for exactly the declared limit is inside the server's stated budget and still
+// 103 bytes (BatchUpdateBlobsRequest) or 157 bytes (ByteStream WriteRequest) over what
+// gRPC will carry. The limit that binds is the one on what a *server* receives, which
+// nothing a client sets can raise, hence the headroom below.
+const (
+	// maxBatchMessageSize is what a server is assumed to receive when it declares more
+	// than this, or nothing: grpc-go's defaultServerMaxReceiveMessageSize, and
+	// grpc-java's.
+	maxBatchMessageSize = 4 * 1024 * 1024
+
+	// batchFramingHeadroom covers the per-blob digest, status and length-delimiter
+	// fields, and a WriteRequest's resource name. Same figure as
+	// bazelbuild/remote-apis-sdks holds back in DefaultMaxBatchSize (4*1024*1024 - 1024).
+	batchFramingHeadroom = 1024
+
+	// minBatchPayload keeps an unusually small declared limit from driving the budget to
+	// zero. It also sizes WriteBlob's chunk buffer, which at zero makes no progress.
+	minBatchPayload = 64 * 1024
+)
+
 type capabilities struct {
 	DigestFunctionSHA256   bool
 	DigestFunctionSHA512   bool
@@ -355,16 +378,24 @@ func learnCapabilities(ctx context.Context, capabilitiesClient remoteexecution_p
 			caps.DigestFunctionSHA512 = true
 		}
 	}
-	caps.MaxBatchTotalSizeBytes = resp.CacheCapabilities.MaxBatchTotalSizeBytes
-	if caps.MaxBatchTotalSizeBytes <= 0 {
-		// Default to 1 MiB if not set.
-		caps.MaxBatchTotalSizeBytes = 1 * 1024 * 1024
+	declared := resp.CacheCapabilities.MaxBatchTotalSizeBytes
+	if declared <= 0 {
+		// Assume 1 MiB when the server declares no limit.
+		declared = 1 * 1024 * 1024
 	}
-	if caps.MaxBatchTotalSizeBytes > 4*1024*1024 {
-		// Cap to 4 MiB to avoid excessive memory usage.
-		caps.MaxBatchTotalSizeBytes = 4 * 1024 * 1024
-	}
+	caps.MaxBatchTotalSizeBytes = batchPayloadBudget(declared)
 	return caps, nil
+}
+
+// batchPayloadBudget turns a batch message limit into how much blob payload may go in
+// one. Headroom comes off whichever limit binds, the server's or ours: a server declaring
+// under 4 MiB may be enforcing a lower transport limit to match.
+func batchPayloadBudget(messageLimit int64) int64 {
+	budget := min(messageLimit, int64(maxBatchMessageSize)) - batchFramingHeadroom
+	if budget < minBatchPayload {
+		return minBatchPayload
+	}
+	return budget
 }
 
 func getCapabilitiesOnce(ctx context.Context, client remoteexecution_proto.CapabilitiesClient, request *remoteexecution_proto.GetCapabilitiesRequest, policy RetryPolicy) (*remoteexecution_proto.ServerCapabilities, error) {

--- a/img_tool/pkg/cas/read_test.go
+++ b/img_tool/pkg/cas/read_test.go
@@ -136,6 +136,50 @@ func rstErr() error {
 	return status.Error(codes.Internal, "stream terminated by RST_STREAM with error code: NO_ERROR")
 }
 
+// fakeCapabilitiesClient answers GetCapabilities with a fixed batch size limit.
+type fakeCapabilitiesClient struct {
+	maxBatchTotalSizeBytes int64
+}
+
+func (f *fakeCapabilitiesClient) GetCapabilities(context.Context, *remoteexecution_proto.GetCapabilitiesRequest, ...grpc.CallOption) (*remoteexecution_proto.ServerCapabilities, error) {
+	return &remoteexecution_proto.ServerCapabilities{
+		CacheCapabilities: &remoteexecution_proto.CacheCapabilities{
+			DigestFunctions:        []remoteexecution_proto.DigestFunction_Value{remoteexecution_proto.DigestFunction_SHA256},
+			MaxBatchTotalSizeBytes: f.maxBatchTotalSizeBytes,
+		},
+	}, nil
+}
+
+func TestLearnCapabilitiesBatchPayloadBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		declared int64
+		want     int64
+	}{
+		{"undeclared falls back to 1 MiB, less headroom", 0, 1*1024*1024 - batchFramingHeadroom},
+		{"a negative declaration is treated as undeclared", -1, 1*1024*1024 - batchFramingHeadroom},
+		{"below the cap still loses headroom", 1 * 1024 * 1024, 1*1024*1024 - batchFramingHeadroom},
+		// The case in #720.
+		{"exactly 4 MiB", 4 * 1024 * 1024, maxBatchMessageSize - batchFramingHeadroom},
+		{"above the cap is clamped to ours", 8 * 1024 * 1024, maxBatchMessageSize - batchFramingHeadroom},
+		{"a tiny declaration is floored", 4096, minBatchPayload},
+		{"a declaration below the headroom is floored", batchFramingHeadroom - 1, minBatchPayload},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeCapabilitiesClient{maxBatchTotalSizeBytes: tc.declared}
+
+			caps, err := learnCapabilities(context.Background(), client, "", newRetryConfig(testRetryPolicy()))
+			if err != nil {
+				t.Fatalf("learnCapabilities returned error: %v", err)
+			}
+
+			if caps.MaxBatchTotalSizeBytes != tc.want {
+				t.Errorf("MaxBatchTotalSizeBytes = %d, want %d", caps.MaxBatchTotalSizeBytes, tc.want)
+			}
+		})
+	}
+}
+
 func TestStreamReadReconnectResumesAfterRST(t *testing.T) {
 	blob := testBlob(1000)
 	fake := &fakeByteStreamClient{


### PR DESCRIPTION
Fixes #720.

Two independent defects on the remote cache path, one commit each. In both, a request the
protocol permits fails at the transport.

## The receive limit

`protohelper.Client` builds every CAS and ByteStream client without setting
`MaxCallRecvMsgSize`, so each keeps grpc-go's 4194304-byte default. An ordinary blob read
then fails when the server answers it with a slightly larger message:

```
ResourceExhausted desc = grpc: received message larger than max (4194309 vs. 4194304)
```

A client cannot avoid this by being careful. The remote execution API places no bound on the
size of a `ReadResponse`, and `GetCapabilities` exposes no field from which a client could
derive one, so how a server divides a blob into responses is its own choice and any
conforming server may exceed the default. Bazel raises the same limit to
`Integer.MAX_VALUE`; `bazelbuild/remote-apis-sdks` raises it to 100 MiB.

The first commit takes the 100 MiB figure and keeps it finite, since the limit is per call
and `img deploy` pools one connection per job, so it bounds a single response rather than
total allocation. `IMG_REAPI_MAX_RECV_MSG_SIZE` overrides it, floored at grpc-go's own
4 MiB: a lower value only fails reads an unconfigured client would have completed, and
`pkg/cas` retries the resulting `ResourceExhausted` as transient, so a typo would cost a
full retry budget per blob before anything is reported.

## The batch budget

`learnCapabilities` read `max_batch_total_size_bytes` as the payload it could put in one
batch request, clamped to exactly 4 MiB. That figure bounds the payload, not the serialized
message: the specification calls it the "maximum total size of blobs" and names the
transport's message limit as a separate constraint. Buildbarn enforces it that way, counting
only digest sizes, and keeps its gRPC receive limit as an unrelated setting.

So a request for exactly the declared limit is inside the server's stated budget and still
over what gRPC will carry. Measured at a 4 MiB payload, a `BatchUpdateBlobsRequest` comes out
103 bytes over and a ByteStream `WriteRequest` 157 bytes over.

The second commit holds back a fixed 1 KiB, matching `DefaultMaxBatchSize` in
`remote-apis-sdks`, and takes it off whichever limit binds rather than only off the 4 MiB
assumption. A server declaring less than 4 MiB may be enforcing a matching transport limit,
and clamping alone would leave it with the same overflow.

Raising the receive limit does not address this. The message the server refuses is one this
client is sending, and the limit that binds is the server's own inbound default, which
nothing a client sets on its own receiving can raise.

## Scope

`img deploy` does not reach the second fix. It never asks for capabilities and uses a fixed
2 MiB budget; the BES and CAS registry paths are the ones that call `learnCapabilities`.

`img_tool/pkg/load/load.go` has the same class of problem on the `image_load` send path
against containerd (#439), where an 8 MiB `writeBufferSize` currently works around it.
Different transport, so it is left alone here.

## Verification

Both defects are covered by tests that fail without the fix, so neither needs a live server
to reproduce. For the receive limit, a loopback ByteStream server answers a read with 5 MiB:
a default client gets `ResourceExhausted` and a `Client`-built one does not. Removing the
dial option, or appending it instead of prepending it, fails the test. For the batch budget,
a `GetCapabilities` fake declares a range of limits and the test pins the resulting payload
budget rather than the constant.

From `img_tool/`:

```
$ gofmt -l pkg/auth/protohelper pkg/cas
$ go build ./...
$ go vet ./pkg/auth/protohelper/... ./pkg/cas/...
$ go test -count=1 ./pkg/auth/protohelper/... ./pkg/cas/...
ok  github.com/bazel-contrib/rules_img/img_tool/pkg/auth/protohelper  0.230s
ok  github.com/bazel-contrib/rules_img/img_tool/pkg/cas               0.556s
```

From the repo root:

```
$ bazel test --nocache_test_results @rules_img_tool//pkg/cas:cas_test @rules_img_tool//pkg/auth/protohelper:protohelper_test
@rules_img_tool//pkg/auth/protohelper:protohelper_test   PASSED in 0.7s
@rules_img_tool//pkg/cas:cas_test                        PASSED in 0.6s

$ bazel test //util:buildifier.check
//util:buildifier.check   PASSED in 0.5s

$ bazel run //util:gazelle    # no change to either BUILD.bazel this PR touches
```

`go test ./...` across `img_tool` also fails `pkg/tarcas`'s `TestReconstructEstargzGzip` under
Go 1.27, inside `stargz-snapshotter/estargz`. It reproduces on `main` at 41be0a2 and passes
under the Bazel-pinned toolchain, so it is unrelated to this change.

## Open questions

- Is `IMG_REAPI_MAX_RECV_MSG_SIZE` wanted at all, or would a plain constant be preferred? It
  follows the `IMG_REAPI_*` convention from #707 and the escape hatch is cheap, but the prefix
  does not quite fit: `protohelper.Client` also builds the `IMG_BLOB_CACHE_ENDPOINT` client,
  which is not a remote execution API service.
- Is 100 MiB the right figure, or would you rather follow Bazel and drop the ceiling? It is
  `remote-apis-sdks`' number, not a measured requirement.
- `warnInvalidEnv` is duplicated into `protohelper` rather than exported from `pkg/cas`.
  `pkg/cas` does not import `protohelper`, and exporting the helper would widen a public API
  for one caller, but say if you would rather it went the other way.
- #439 as a follow-up, if the send-side limit is worth the same treatment.
