### PR TITLE
fix(gateway): refresh rejected upstream credentials

### DIFF
--- a/img_tool/pkg/serve/gateway/existencecache_serve_test.go
+++ b/img_tool/pkg/serve/gateway/existencecache_serve_test.go
@@ -192,8 +192,12 @@ func TestBlobExistenceCacheStoresOnlyPresentBlobs(t *testing.T) {
 
 			head(h, testUpstreamHost, testBlobPath)
 			head(h, testUpstreamHost, testBlobPath)
-			if got := up.count(http.MethodHead, testBlobPath); got != 2 {
-				t.Errorf("a %d answer was cached (%d upstream probes, want 2)", status, got)
+			wantProbes := 2
+			if status == http.StatusUnauthorized {
+				wantProbes = 4
+			}
+			if got := up.count(http.MethodHead, testBlobPath); got != wantProbes {
+				t.Errorf("a %d answer was cached (%d upstream probes, want %d)", status, got, wantProbes)
 			}
 			if entries := h.blobCache.stats().entries; entries != 0 {
 				t.Errorf("cache holds %d entries after a %d answer, want 0", entries, status)
@@ -465,8 +469,12 @@ func TestBlobExistenceCacheIgnoresUnfinishedUploads(t *testing.T) {
 			if got := head(h, testUpstreamHost, testBlobPath); got.StatusCode != tc.status {
 				t.Errorf("probe status = %d, want the upstream's %d: it must not have been answered from the cache", got.StatusCode, tc.status)
 			}
-			if got := up.count(http.MethodHead, testBlobPath); got != 1 {
-				t.Errorf("upstream saw %d probes, want 1", got)
+			wantProbes := 1
+			if tc.status == http.StatusUnauthorized {
+				wantProbes = 2
+			}
+			if got := up.count(http.MethodHead, testBlobPath); got != wantProbes {
+				t.Errorf("upstream saw %d probes, want %d", got, wantProbes)
 			}
 		})
 	}

--- a/img_tool/pkg/serve/gateway/gateway.go
+++ b/img_tool/pkg/serve/gateway/gateway.go
@@ -771,39 +771,58 @@ func (h *Handler) forward(obs *observation, w http.ResponseWriter, r *http.Reque
 		action = transport.PushScope
 	}
 
-	rt, err := h.authTransport(r.Context(), obs, repo, action)
-	if err != nil {
-		h.writeError(obs, w, r, http.StatusBadGateway, "UNAUTHORIZED", authErrorType(err),
-			fmt.Sprintf("authenticating to upstream %s: %v", repo.RegistryStr(), err))
-		return
-	}
-
 	// Preserve the exact request URI (path + query) as received.
 	upstreamURL := repo.Scheme() + "://" + repo.RegistryStr() + r.URL.RequestURI()
-	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, r.Body)
-	if err != nil {
-		h.writeError(obs, w, r, http.StatusBadGateway, "UNKNOWN", errBadUpstreamRequest,
-			fmt.Sprintf("building upstream request: %v", err))
-		return
-	}
-	copyHeader(outReq.Header, r.Header)
-	outReq.ContentLength = r.ContentLength
+	var resp *http.Response
+	var started time.Time
+	for attempt := 0; attempt < 2; attempt++ {
+		rt, auth, err := h.authTransport(r.Context(), obs, repo, action)
+		if err != nil {
+			h.writeError(obs, w, r, http.StatusBadGateway, "UNAUTHORIZED", authErrorType(err),
+				fmt.Sprintf("authenticating to upstream %s: %v", repo.RegistryStr(), err))
+			return
+		}
 
-	// Use an http.Client so redirects (e.g. a blob GET pointing at CDN/blob
-	// storage) are followed transparently. checkRedirect only follows for safe
-	// read methods and refuses redirects to private/link-local addresses.
-	client := &http.Client{Transport: rt, CheckRedirect: checkRedirect(r.Method)}
-	started := time.Now()
-	resp, err := client.Do(outReq)
-	if err != nil {
-		// A delete whose answer never came back may have taken effect all the same,
-		// and an entry for a blob that is gone is the one wrong answer this cache can
-		// give. The peers are not told: with no answer there is no evidence a blob
-		// left, and each of them will hear it from their own traffic or its TTL.
-		h.forgetDeletedBlob(r.Context(), repo, cls, nil)
-		h.writeError(obs, w, r, http.StatusBadGateway, "UNKNOWN", transportErrorType(err),
-			fmt.Sprintf("forwarding to upstream %s: %v", repo.RegistryStr(), err))
-		return
+		body := r.Body
+		if attempt > 0 {
+			body = http.NoBody
+		}
+		outReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, body)
+		if err != nil {
+			h.writeError(obs, w, r, http.StatusBadGateway, "UNKNOWN", errBadUpstreamRequest,
+				fmt.Sprintf("building upstream request: %v", err))
+			return
+		}
+		copyHeader(outReq.Header, r.Header)
+		outReq.ContentLength = r.ContentLength
+
+		// Use an http.Client so redirects (e.g. a blob GET pointing at CDN/blob
+		// storage) are followed transparently. checkRedirect only follows for safe
+		// read methods and refuses redirects to private/link-local addresses.
+		client := &http.Client{Transport: rt, CheckRedirect: checkRedirect(r.Method)}
+		started = time.Now()
+		resp, err = client.Do(outReq)
+		if err != nil {
+			// A delete whose answer never came back may have taken effect all the same,
+			// and an entry for a blob that is gone is the one wrong answer this cache can
+			// give. The peers are not told: with no answer there is no evidence a blob
+			// left, and each of them will hear it from their own traffic or its TTL.
+			h.forgetDeletedBlob(r.Context(), repo, cls, nil)
+			h.writeError(obs, w, r, http.StatusBadGateway, "UNKNOWN", transportErrorType(err),
+				fmt.Sprintf("forwarding to upstream %s: %v", repo.RegistryStr(), err))
+			return
+		}
+
+		if attempt == 0 && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden) {
+			h.cache.invalidate(auth)
+			// Incoming request bodies are streams and cannot be replayed. A zero
+			// Content-Length is the server-side guarantee that no bytes were consumed.
+			if r.ContentLength == 0 {
+				_ = resp.Body.Close()
+				continue
+			}
+		}
+		break
 	}
 	defer resp.Body.Close()
 	obs.upstreamResponse(r.Context(), cls, resp.StatusCode, time.Since(started))
@@ -840,7 +859,7 @@ func (h *Handler) forward(obs *observation, w http.ResponseWriter, r *http.Reque
 // authTransport returns a cached authenticated RoundTripper for the given
 // repository and scope action ("pull" or "push,pull"). It resolves credentials
 // from the keychain and performs the crane ping + token-exchange handshake.
-func (h *Handler) authTransport(reqCtx context.Context, obs *observation, repo name.Repository, action string) (http.RoundTripper, error) {
+func (h *Handler) authTransport(reqCtx context.Context, obs *observation, repo name.Repository, action string) (http.RoundTripper, authCacheHandle, error) {
 	key := repo.String() + "|" + action
 	return h.cache.get(key, func() (http.RoundTripper, error) {
 		// The resulting transport is cached and shared across requests, so the
@@ -1133,7 +1152,13 @@ type authEntry struct {
 	err  error
 }
 
-func (c *authCache) get(key string, create func() (http.RoundTripper, error)) (http.RoundTripper, error) {
+// authCacheHandle identifies the generation returned by one cache lookup.
+type authCacheHandle struct {
+	key   string
+	entry *authEntry
+}
+
+func (c *authCache) get(key string, create func() (http.RoundTripper, error)) (http.RoundTripper, authCacheHandle, error) {
 	c.mu.Lock()
 	e, ok := c.inner[key]
 	if !ok {
@@ -1154,5 +1179,16 @@ func (c *authCache) get(key string, create func() (http.RoundTripper, error)) (h
 		}
 		c.mu.Unlock()
 	}
-	return e.rt, e.err
+	return e.rt, authCacheHandle{key: key, entry: e}, e.err
+}
+
+// invalidate removes handle's entry only if it is still the current generation.
+// An old request must not evict the replacement installed after another request
+// observed the same expired credential.
+func (c *authCache) invalidate(handle authCacheHandle) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inner[handle.key] == handle.entry {
+		delete(c.inner, handle.key)
+	}
 }

--- a/img_tool/pkg/serve/gateway/gateway_test.go
+++ b/img_tool/pkg/serve/gateway/gateway_test.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -84,13 +86,161 @@ func allowHostPolicy(t *testing.T, host string, ops ...string) *CompiledPolicy {
 }
 
 func do(h *Handler, method, host, path string) *http.Response {
-	r, _ := http.NewRequest(method, "http://gateway"+path, nil)
+	return doBody(h, method, host, path, "")
+}
+
+func doBody(h *Handler, method, host, path, body string) *http.Response {
+	r, _ := http.NewRequest(method, "http://gateway"+path, strings.NewReader(body))
 	if host != "" {
 		r.Header.Set(clientgateway.OriginalHostHeader, host)
 	}
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, r)
 	return rec.Result()
+}
+
+type rotatingKeychain struct {
+	resolutions int
+}
+
+func (k *rotatingKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	return k.ResolveContext(context.Background(), target)
+}
+
+func (k *rotatingKeychain) ResolveContext(context.Context, authn.Resource) (authn.Authenticator, error) {
+	k.resolutions++
+	return &authn.Basic{Username: "AWS", Password: fmt.Sprintf("token-%d", k.resolutions)}, nil
+}
+
+type expiringAuthUpstream struct {
+	rejectedStatus   int
+	acceptedPassword string
+	attempts         int
+}
+
+func (u *expiringAuthUpstream) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path == "/v2/" {
+		return upstreamResponse(http.StatusUnauthorized, http.Header{
+			"WWW-Authenticate": {`Basic realm="registry.test"`},
+		}, ""), nil
+	}
+	u.attempts++
+	_, password, ok := req.BasicAuth()
+	if !ok || password != u.acceptedPassword {
+		return upstreamResponse(u.rejectedStatus, nil, "rejected"), nil
+	}
+	return upstreamResponse(http.StatusOK, http.Header{
+		"Content-Type": {"application/vnd.oci.image.manifest.v1+json"},
+	}, `{"schemaVersion":2}`), nil
+}
+
+func newAuthRefreshHandler(t *testing.T, keychain authn.Keychain, base http.RoundTripper) *Handler {
+	t.Helper()
+	return New(
+		WithAuthorizer(allowHostPolicy(t, testUpstreamHost, "manifest:read", "manifest:write")),
+		WithKeychain(keychain),
+		WithLogger(log.New(io.Discard, "", 0)),
+		WithBaseTransport(base),
+	)
+}
+
+func TestForwardRefreshesRejectedAuthentication(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			keychain := &rotatingKeychain{}
+			upstream := &expiringAuthUpstream{rejectedStatus: status, acceptedPassword: "token-2"}
+			h := newAuthRefreshHandler(t, keychain, upstream)
+
+			resp := do(h, http.MethodGet, testUpstreamHost, "/v2/app/manifests/latest")
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.StatusCode)
+			}
+			if keychain.resolutions != 2 {
+				t.Fatalf("keychain resolutions = %d, want 2", keychain.resolutions)
+			}
+			if upstream.attempts != 2 {
+				t.Fatalf("upstream attempts = %d, want 2", upstream.attempts)
+			}
+
+			resp = do(h, http.MethodGet, testUpstreamHost, "/v2/app/manifests/latest")
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("cached refreshed auth status = %d, want 200", resp.StatusCode)
+			}
+			if keychain.resolutions != 2 {
+				t.Fatalf("keychain resolutions after cache hit = %d, want 2", keychain.resolutions)
+			}
+		})
+	}
+}
+
+func TestForwardRetriesRejectedAuthenticationOnlyOnce(t *testing.T) {
+	keychain := &rotatingKeychain{}
+	upstream := &expiringAuthUpstream{rejectedStatus: http.StatusForbidden, acceptedPassword: "never"}
+	h := newAuthRefreshHandler(t, keychain, upstream)
+
+	resp := do(h, http.MethodGet, testUpstreamHost, "/v2/app/manifests/latest")
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if keychain.resolutions != 2 {
+		t.Fatalf("keychain resolutions = %d, want 2", keychain.resolutions)
+	}
+	if upstream.attempts != 2 {
+		t.Fatalf("upstream attempts = %d, want 2", upstream.attempts)
+	}
+}
+
+func TestForwardDoesNotReplayRequestBody(t *testing.T) {
+	keychain := &rotatingKeychain{}
+	upstream := &expiringAuthUpstream{rejectedStatus: http.StatusForbidden, acceptedPassword: "token-2"}
+	h := newAuthRefreshHandler(t, keychain, upstream)
+
+	resp := doBody(h, http.MethodPut, testUpstreamHost, "/v2/app/manifests/latest", `{"schemaVersion":2}`)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if upstream.attempts != 1 {
+		t.Fatalf("upstream attempts = %d, want 1", upstream.attempts)
+	}
+
+	resp = doBody(h, http.MethodPut, testUpstreamHost, "/v2/app/manifests/latest", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status with refreshed auth = %d, want 200", resp.StatusCode)
+	}
+	if keychain.resolutions != 2 {
+		t.Fatalf("keychain resolutions = %d, want 2", keychain.resolutions)
+	}
+}
+
+func TestAuthCacheStaleHandleDoesNotInvalidateReplacement(t *testing.T) {
+	cache := authCache{inner: make(map[string]*authEntry)}
+	created := 0
+	create := func() (http.RoundTripper, error) {
+		created++
+		return &fakeUpstreamRT{}, nil
+	}
+
+	_, stale, err := cache.get("repo|pull", create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.invalidate(stale)
+	_, replacement, err := cache.get("repo|pull", create)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cache.invalidate(stale)
+	_, current, err := cache.get("repo|pull", create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.entry != replacement.entry {
+		t.Fatal("stale handle invalidated the replacement entry")
+	}
+	if created != 2 {
+		t.Fatalf("created %d transports, want 2", created)
+	}
 }
 
 func TestForwardManifestRead(t *testing.T) {


### PR DESCRIPTION
## Summary

- invalidate cached upstream authentication after a 401 or 403
- retry bodyless requests once with freshly resolved credentials
- avoid replaying streamed request bodies while refreshing subsequent requests

Closes #715

## Testing

- `go test ./pkg/serve/gateway`
- `CGO_ENABLED=0 go build ./...`
- `bazel test //pkg/serve/gateway:gateway_test`

Generated with [Codex](https://openai.com/codex/).