### PR TITLE
load: probe custom containerd-proxy socket path

### DIFF
--- a/img_tool/pkg/containerd/support.go
+++ b/img_tool/pkg/containerd/support.go
@@ -69,6 +69,12 @@ func FindContainerdSocket() (string, error) {
 		"/var/run/docker/containerd/containerd.sock",
 	}
 
+	// Add home directory based socket path (e.g. macOS containerd-proxy)
+	// See: https://github.com/bazel-contrib/rules_img/issues/199
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		socketPaths = append(socketPaths, filepath.Join(homeDir, ".docker/run/containerd.sock"))
+	}
+
 	if xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR"); xdgRuntimeDir != "" {
 		socketPaths = append(socketPaths, filepath.Join(xdgRuntimeDir, "containerd/containerd.sock"))
 		socketPaths = append(socketPaths, filepath.Join(xdgRuntimeDir, "docker/containerd/containerd.sock"))


### PR DESCRIPTION
This PR adds `~/.docker/run/containerd.sock` as a probed socket path for containerd.

Context: On macOS, we're currently using a containerd-proxy based on the examples in https://github.com/bazel-contrib/rules_img/issues/199. To make this work with rules_img, we set `CONTAINERD_ADDRESS` in our envrc and add `common --action_env=CONTAINERD_ADDRESS` to bazelrc.

However, this has the downside of contributing the value of CONTAINERD_ADDRESS to every action's digest. We're currently working on bringing remote caching to our developer workstations and this causes every action to be a cache miss. Adding this to rules_img solves this for us.