### PR TITLE
fix(import): import index children whose config has no diff_ids

### DIFF
--- a/img/private/BUILD.bazel
+++ b/img/private/BUILD.bazel
@@ -1,7 +1,10 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//img/private:download_blobs_test.bzl", "download_blobs_test_suite")
+load("//img/private:import_test.bzl", "import_test_suite")
 
 download_blobs_test_suite(name = "download_blobs_test")
+
+import_test_suite(name = "import_test")
 
 bzl_library(
     name = "import",

--- a/img/private/import.bzl
+++ b/img/private/import.bzl
@@ -53,24 +53,36 @@ def _write_layer_info(ctx, manifest, config, history, layer_index, index_positio
 
     rootfs = config.get("rootfs", {})
     diff_ids = rootfs.get("diff_ids", [])
-    if layer_index >= len(diff_ids):
-        fail("layer index out of range for config: {}".format(layer_index))
-    diff_id = diff_ids[layer_index]
-    if not diff_id.startswith("sha256:"):
-        fail("invalid diff_id: {}".format(diff_id))
+
+    # A config that declares no rootfs layers at all does not describe an image.
+    # That is what an index's attestation children look like (buildx marks them
+    # with the vnd.docker.reference.type annotation and an "unknown/unknown"
+    # platform, and writes an empty config), and what a non-image OCI artifact
+    # looks like. Such layers have no diff_id to record; they are still imported,
+    # because the index blob is used verbatim and keeps referring to them.
+    # A config that has *some* diff_ids but fewer than the manifest has layers is
+    # a different matter -- that is a corrupt image, and still an error.
+    diff_id = None
+    if len(diff_ids) > 0:
+        if layer_index >= len(diff_ids):
+            fail("layer index out of range for config: {}".format(layer_index))
+        diff_id = diff_ids[layer_index]
+        if not diff_id.startswith("sha256:"):
+            fail("invalid diff_id: {}".format(diff_id))
 
     if history and layer_index < len(history):
         layer_history = history[layer_index]
     else:
         layer_history = []
     metadata = dict(
-        diff_id = diff_id,
         mediaType = media_type,
         digest = digest,
         size = size,
         annotations = layer.get("annotations", {}),
         history = layer_history,
     )
+    if diff_id != None:
+        metadata["diff_id"] = diff_id
     index_position_str = "" if index_position == None else str(index_position) + "_"
     layer_metadata = ctx.actions.declare_file(ctx.attr.name + "_{}{}_layer_metadata.json".format(index_position_str, layer_index))
     ctx.actions.write(layer_metadata, json.encode(metadata))

--- a/img/private/import_test.bzl
+++ b/img/private/import_test.bzl
@@ -1,0 +1,179 @@
+"""Analysis tests for image_import."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//img/private:import.bzl", "image_import")
+load("//img/private/providers:index_info.bzl", "ImageIndexInfo")
+
+# Digests are opaque keys here: nothing verifies that a blob hashes to the digest
+# it is registered under during analysis, so these are readable placeholders.
+_INDEX_DIGEST = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+_AMD64_MANIFEST_DIGEST = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+_AMD64_CONFIG_DIGEST = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+_ARM64_MANIFEST_DIGEST = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+_ARM64_CONFIG_DIGEST = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+_ATTESTATION_MANIFEST_DIGEST = "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+_ATTESTATION_CONFIG_DIGEST = "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+_LAYER_DIGEST = "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+_DIFF_ID = "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+_ATTESTATION_LAYER_DIGEST = "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+
+def _image_config(architecture):
+    return json.encode(dict(
+        architecture = architecture,
+        os = "linux",
+        rootfs = dict(type = "layers", diff_ids = [_DIFF_ID]),
+    ))
+
+def _image_manifest(config_digest):
+    return json.encode(dict(
+        schemaVersion = 2,
+        mediaType = "application/vnd.oci.image.manifest.v1+json",
+        config = dict(
+            mediaType = "application/vnd.oci.image.config.v1+json",
+            digest = config_digest,
+            size = 1,
+        ),
+        layers = [dict(
+            mediaType = "application/vnd.oci.image.layer.v1.tar+gzip",
+            digest = _LAYER_DIGEST,
+            size = 1,
+        )],
+    ))
+
+# A buildx attestation manifest: an empty config (no rootfs.diff_ids) with in-toto
+# layers. Describing it as an image fails, which is what regressed image_import.
+_ATTESTATION_CONFIG = json.encode(dict())
+
+_ATTESTATION_MANIFEST = json.encode(dict(
+    schemaVersion = 2,
+    mediaType = "application/vnd.oci.image.manifest.v1+json",
+    config = dict(
+        mediaType = "application/vnd.oci.image.config.v1+json",
+        digest = _ATTESTATION_CONFIG_DIGEST,
+        size = 1,
+    ),
+    layers = [dict(
+        mediaType = "application/vnd.in-toto+json",
+        digest = _ATTESTATION_LAYER_DIGEST,
+        size = 1,
+    )],
+))
+
+_INDEX = json.encode(dict(
+    schemaVersion = 2,
+    mediaType = "application/vnd.oci.image.index.v1+json",
+    manifests = [
+        dict(
+            mediaType = "application/vnd.oci.image.manifest.v1+json",
+            digest = _AMD64_MANIFEST_DIGEST,
+            size = 1,
+            platform = dict(architecture = "amd64", os = "linux"),
+        ),
+        # No platform in the descriptor: the platform is read from the config.
+        # This must not be mistaken for an attestation.
+        dict(
+            mediaType = "application/vnd.oci.image.manifest.v1+json",
+            digest = _ARM64_MANIFEST_DIGEST,
+            size = 1,
+        ),
+        dict(
+            mediaType = "application/vnd.oci.image.manifest.v1+json",
+            digest = _ATTESTATION_MANIFEST_DIGEST,
+            size = 1,
+            platform = dict(architecture = "unknown", os = "unknown"),
+            annotations = {"vnd.docker.reference.type": "attestation-manifest"},
+        ),
+    ],
+))
+
+_BLOBS = {
+    _INDEX_DIGEST: _INDEX,
+    _AMD64_MANIFEST_DIGEST: _image_manifest(_AMD64_CONFIG_DIGEST),
+    _AMD64_CONFIG_DIGEST: _image_config("amd64"),
+    _ARM64_MANIFEST_DIGEST: _image_manifest(_ARM64_CONFIG_DIGEST),
+    _ARM64_CONFIG_DIGEST: _image_config("arm64"),
+    _ATTESTATION_MANIFEST_DIGEST: _ATTESTATION_MANIFEST,
+    _ATTESTATION_CONFIG_DIGEST: _ATTESTATION_CONFIG,
+}
+
+def _layer_metadata(env):
+    """Returns the written layer metadata JSON, keyed by output basename."""
+    metadata = {}
+    for action in analysistest.target_actions(env):
+        for output in action.outputs.to_list():
+            if output.basename.endswith("_layer_metadata.json"):
+                metadata[output.basename] = json.decode(action.content)
+    return metadata
+
+def _imports_attestation_manifests_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+    index_info = target_under_test[ImageIndexInfo]
+
+    # Every child of the index is imported, including the attestation: the index
+    # blob is used verbatim, so a deploy has to be able to carry them all.
+    platforms = [
+        "{}/{}".format(manifest.os, manifest.architecture)
+        for manifest in index_info.manifests
+    ]
+    asserts.equals(env, ["linux/amd64", "linux/arm64", "unknown/unknown"], platforms)
+
+    # The attestation's config declares no rootfs layers, so its layer carries no
+    # diff_id -- while a real image layer still does.
+    prefix = target_under_test.label.name
+    metadata = _layer_metadata(env)
+    asserts.equals(
+        env,
+        _DIFF_ID,
+        metadata.get(prefix + "_0_0_layer_metadata.json", {}).get("diff_id"),
+    )
+    asserts.equals(
+        env,
+        None,
+        metadata.get(prefix + "_2_0_layer_metadata.json", {}).get("diff_id"),
+    )
+    return analysistest.end(env)
+
+_imports_attestation_manifests_test = analysistest.make(_imports_attestation_manifests_test_impl)
+
+def import_test_suite(name):
+    """Declare image_import analysis tests.
+
+    Args:
+        name: Name for the test suite.
+    """
+    blob_files = {}
+    for digest, content in _BLOBS.items():
+        blob = "{}_blob_{}".format(name, digest.removeprefix("sha256:")[:4])
+        write_file(
+            name = blob,
+            out = blob + ".json",
+            content = [content],
+            tags = ["manual"],
+        )
+        blob_files[digest] = ":" + blob
+
+    subject = name + "_subject"
+    image_import(
+        name = subject,
+        digest = _INDEX_DIGEST,
+        data = _BLOBS,
+        files = blob_files,
+        registries = ["registry.example.com"],
+        repository = "example/image",
+        tag = "latest",
+        tags = ["manual"],
+    )
+
+    test = name + "_imports_attestation_manifests_test"
+    _imports_attestation_manifests_test(
+        name = test,
+        size = "small",
+        target_under_test = ":" + subject,
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [":" + test],
+    )


### PR DESCRIPTION
`image_import` maps each layer of an index child onto the child config's `rootfs.diff_ids`. buildx attestation children -- annotated `vnd.docker.reference.type=attestation-manifest`, platform `unknown/unknown` -- normally carry a full config with diff_ids for their in-toto layers, so they import like any other child. Registries that publish an attestation manifest with an *empty* config have no diff_ids to map onto, and the import failed at analysis time:

    Error in fail: layer index out of range for config: 0

A config that declares no rootfs layers at all does not describe an image, so there is no diff_id to record: import those layers without one, and omit the field from the layer metadata. A config that has some diff_ids but fewer than the manifest has layers is a corrupt image and still an error.

The child is kept rather than dropped from `ImageIndexInfo.manifests`. The index blob is used verbatim on the push and load paths, so it goes on referring to every child it was pulled with; a child that is not in the provider is not materialized for the deploy, and pushing a pulled index then fails with `image manifest <digest> not found in VFS`.

Fixes #713
