### PR TITLE
fix(registry): do not collect a manifest while a client tags it

### DIFF
--- a/img_tool/pkg/registry/collector.go
+++ b/img_tool/pkg/registry/collector.go
@@ -61,6 +61,9 @@ type Collector struct {
 	interval time.Duration
 	now      func() time.Time
 
+	// sweeps excludes a sweep from a write that takes more than one call to
+	// the Store. A writer holds it for reading, a sweep for writing.
+	sweeps        sync.RWMutex
 	lock          sync.Mutex
 	lastSweep     time.Time
 	manifests     map[manifestKey]time.Time
@@ -251,6 +254,29 @@ func (c *Collector) ForgetBlob(digest v1.Hash) {
 	delete(c.blobs, digest)
 }
 
+// writing announces a write that a sweep must not run in the middle of, and
+// returns the function that ends it.
+//
+// Storing a manifest and then the tag that names it is two calls to a Store
+// that offers no transactions, and in between them the manifest is a manifest
+// nothing points at. One sweep landing there is harmless -- it adopts what it
+// has not seen before, so the first sweep never collects. A second one finds
+// that adopted manifest past its TTL with no root reaching it and collects it,
+// out from under the tag that is about to be written. What is left is a tag
+// resolving to a manifest that is gone: a 404 for a reference the client was
+// told, moments later, that the registry had created.
+//
+// Holding this for the whole write is what makes the pair atomic as far as the
+// Collector is concerned. It is the outer of the two locks: a writer takes it
+// before touching anything, and lock only afterwards.
+func (c *Collector) writing() func() {
+	if c == nil {
+		return func() {}
+	}
+	c.sweeps.RLock()
+	return c.sweeps.RUnlock
+}
+
 // MaybeCollect sweeps if the configured interval has passed since the last
 // sweep. Handlers call it before serving a request, so a request arriving after
 // something expired does not see it.
@@ -274,11 +300,13 @@ func (c *Collector) Collect() CollectStats {
 		return CollectStats{}
 	}
 
+	c.sweeps.Lock()
 	c.lock.Lock()
 	live := c.markLocked()
 	stats, collectedBlobs := c.sweepLocked(live)
 	c.lastSweep = c.now()
 	c.lock.Unlock()
+	c.sweeps.Unlock()
 
 	c.reportCollectedBlobs(collectedBlobs)
 	return stats

--- a/img_tool/pkg/registry/manifest.go
+++ b/img_tool/pkg/registry/manifest.go
@@ -224,8 +224,11 @@ func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regErro
 
 		// A manifest is stored once, under its digest. A tag is a pointer to
 		// that digest rather than a second copy, so the two cannot be evicted
-		// independently of one another.
+		// independently of one another. Writing them is still two calls to the
+		// Store, so the write is announced to the collector: a sweep that ran
+		// between them would see a manifest no tag names yet.
 		// See https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier.
+		done := m.collector.writing()
 		m.store.PutManifest(repo, h, mf)
 		if target != h.String() {
 			m.store.PutTag(repo, target, h)
@@ -237,6 +240,7 @@ func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regErro
 		for _, blob := range parseReferences(mf).blobs {
 			m.collector.TouchBlob(repo, blob.digest, blob.size)
 		}
+		done()
 
 		resp.Header().Set("Docker-Content-Digest", h.String())
 		resp.WriteHeader(http.StatusCreated)

--- a/img_tool/pkg/registry/registry_gc_test.go
+++ b/img_tool/pkg/registry/registry_gc_test.go
@@ -510,8 +510,13 @@ func TestNewRejectsAStoreTheCollectorDoesNotUse(t *testing.T) {
 // nanosecond so a sweep runs on practically every request. Anything reachable
 // from a tag has to survive that; run under -race it also covers the lock order
 // between the collector and the store.
+//
+// The store leaves a gap between storing a manifest and tagging it, which is
+// the moment a push is most exposed: the manifest is there and nothing points
+// at it yet. Timing alone hits that window rarely enough to make the test a
+// flake rather than a check, so it is widened here on purpose.
 func TestRegistryKeepsTaggedManifestsWhileCollectingConcurrently(t *testing.T) {
-	store := NewMemStore()
+	store := untaggedForAWhileStore{Store: NewMemStore(), gap: time.Millisecond}
 	collector := NewCollector(store, CollectorConfig{TTL: time.Nanosecond, Interval: time.Nanosecond})
 	handler := New(
 		WithStore(store),
@@ -577,6 +582,19 @@ func TestRegistryKeepsTaggedManifestsWhileCollectingConcurrently(t *testing.T) {
 			}
 		}
 	}
+}
+
+// untaggedForAWhileStore waits before pointing a tag at the manifest it names,
+// leaving the manifest untagged for long enough that a concurrent sweep is
+// certain to land in between rather than now and then.
+type untaggedForAWhileStore struct {
+	Store
+	gap time.Duration
+}
+
+func (s untaggedForAWhileStore) PutTag(repo, tag string, digest v1.Hash) {
+	time.Sleep(s.gap)
+	s.Store.PutTag(repo, tag, digest)
 }
 
 func assertErrorCode(t *testing.T, recorder *httptest.ResponseRecorder, wantStatus int, wantCode string) {


### PR DESCRIPTION
A push writes the manifest first, and the tag after it. The store has no transactions, thus a sweep can run between the two writes. The first sweep adopts the new manifest. A second sweep finds a manifest that is too old, and no tag points to it. The second sweep deletes the manifest. The tag then points to a manifest that is not there. The registry sends 404 for a reference that it made a moment before.

The collector now has a second lock. A sweep holds this lock to write. A push holds it to read, for all of the push. Thus a sweep cannot run in the middle of a push.

The concurrent test now makes the store slow to write a tag. The sweeps hit the window each time, and not by chance.