### PR TITLE
perf(cas): read the blobs of a compact stream in batches

### DIFF
--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -108,6 +108,33 @@ will not accept.
 `img deploy` does not ask the server for its capabilities and uses a fixed 2 MiB
 budget regardless. The figures above apply to the BES and CAS registry paths.
 
+## Batched reads
+
+Reconstructing a compact layer means reading every file the layer's index
+references out of the cache. A layer of many small files is thousands of such
+references — often tens of kilobytes each — and reading them one at a time costs
+one round trip per file, which on a high-latency link dominates everything else.
+
+So the reference table is read as a list rather than a blob at a time.
+Consecutive references small enough to batch are fetched with a single
+`BatchReadBlobs` request, filled up to the payload budget above, so the cost is a
+round trip per few megabytes instead of per file. References too large for a batch
+keep using ByteStream, one at a time. Blobs are fetched as the layer is written out,
+so a reconstruction never holds more than one batch in memory however long the list
+is.
+
+The 1 KiB of framing headroom above is a fixed reservation, and a read batch holding
+many blobs spends far more than that: every blob in the response carries its own
+digest, status and length delimiters. A batched read therefore charges each blob its
+framing as well as its bytes against the budget, and caps the number of blobs in one
+request, so the message stays inside the limit however small the blobs are.
+
+References the deploy can satisfy without the network — from the layer's input
+directory (shipped by the eager strategies) or from the disk cache — are still
+read straight from disk, and only the gaps between them go to the remote cache.
+Whatever the batch fetches is written into the disk cache on the way through, so
+a later deploy finds it there.
+
 ## Connection pooling
 
 A single gRPC connection multiplexes every request onto one TCP connection, which

--- a/img_tool/cmd/deploy/dedup_cascache_test.go
+++ b/img_tool/cmd/deploy/dedup_cascache_test.go
@@ -74,6 +74,18 @@ func (s *countingBlobSource) ReaderForBlob(_ context.Context, digest cas.Digest)
 	return io.NopCloser(bytes.NewReader(content)), nil
 }
 
+func (s *countingBlobSource) ReaderForBlobs(ctx context.Context, digests []cas.Digest) (io.ReadCloser, error) {
+	var buf bytes.Buffer
+	for _, digest := range digests {
+		content, err := s.ReadBlob(ctx, digest)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(content)
+	}
+	return io.NopCloser(&buf), nil
+}
+
 // readsOf returns how many times the blob with the given "sha256:<hex>" digest was
 // read from the fake CAS.
 func (s *countingBlobSource) readsOf(digest string) int {

--- a/img_tool/pkg/cas/BUILD.bazel
+++ b/img_tool/pkg/cas/BUILD.bazel
@@ -4,8 +4,10 @@ go_library(
     name = "cas",
     srcs = [
         "cache.go",
+        "cachemultiread.go",
         "cachestore.go",
         "error.go",
+        "multiread.go",
         "pool.go",
         "read.go",
         "retry.go",
@@ -29,7 +31,9 @@ go_test(
     size = "small",
     srcs = [
         "cache_test.go",
+        "cachemultiread_test.go",
         "cachestore_test.go",
+        "multiread_test.go",
         "pool_test.go",
         "read_test.go",
         "retry_test.go",

--- a/img_tool/pkg/cas/cache_test.go
+++ b/img_tool/pkg/cas/cache_test.go
@@ -1,6 +1,7 @@
 package cas
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"errors"
@@ -84,6 +85,18 @@ func (f *fakeBlobs) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCl
 		return nil, fmt.Errorf("fake: blob %s not found", digest.hexHash())
 	}
 	return &fakeBlobReader{source: f, data: data, ctx: ctx}, nil
+}
+
+func (f *fakeBlobs) ReaderForBlobs(ctx context.Context, digests []Digest) (io.ReadCloser, error) {
+	var buf bytes.Buffer
+	for _, digest := range digests {
+		data, err := f.ReadBlob(ctx, digest)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(data)
+	}
+	return io.NopCloser(&buf), nil
 }
 
 func (f *fakeBlobs) readCount(digest Digest) int {

--- a/img_tool/pkg/cas/cachemultiread.go
+++ b/img_tool/pkg/cas/cachemultiread.go
@@ -1,0 +1,198 @@
+package cas
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// maxPopulateBytes bounds how much of a blob list a CachingReader fetches --
+// and therefore holds in memory -- in one go. It matches the largest batch the
+// remote cache will serve, so a window is usually a single BatchReadBlobs
+// request. A blob bigger than this is read on its own through the per-blob path,
+// which streams it into the cache instead of buffering it.
+const maxPopulateBytes = 4 << 20
+
+// ReaderForBlobs reads a whole list of blobs as one stream, serving the blobs
+// the cache directory already has from disk and fetching the rest from upstream
+// in batches.
+//
+// The fetched blobs are cached on the way through, so a later read -- in this
+// process or the next one -- is a cache hit just as it would be after
+// [CachingReader.ReaderForBlob]. Unlike ReaderForBlob, a batched fetch does not
+// register itself for in-flight deduplication: a blob another reader is already
+// fetching is left to that reader (and read through the per-blob path), but two
+// batches that start at the same time may fetch the same blob twice. That costs
+// a duplicated download at worst, never correctness.
+//
+// Local problems never fail a read here either: a blob that cannot be written
+// to the cache directory is still delivered, just not cached.
+func (c *CachingReader) ReaderForBlobs(ctx context.Context, digests []Digest) (io.ReadCloser, error) {
+	// Drop empty blobs: they contribute no bytes, and keeping them would split a
+	// window in two for nothing.
+	wanted := make([]Digest, 0, len(digests))
+	for _, digest := range digests {
+		if digest.SizeBytes > 0 {
+			wanted = append(wanted, digest)
+		}
+	}
+	return &cachedMultiReader{cache: c, ctx: ctx, digests: wanted}, nil
+}
+
+// cachedMultiReader delivers a list of blobs as one stream, pulling the ones the
+// cache does not have from upstream a window at a time.
+type cachedMultiReader struct {
+	cache   *CachingReader
+	ctx     context.Context
+	digests []Digest
+
+	next    int           // index of the next digest to deliver
+	fetched [][]byte      // undelivered blobs of the current window, in order
+	cur     io.ReadCloser // per-blob reader for a cache hit or a joined fetch
+	err     error         // sticky: the stream delivers nothing after a failure
+}
+
+func (r *cachedMultiReader) Read(p []byte) (int, error) {
+	for {
+		if r.err != nil {
+			return 0, r.err
+		}
+		switch {
+		case len(r.fetched) > 0:
+			n := copy(p, r.fetched[0])
+			r.fetched[0] = r.fetched[0][n:]
+			if len(r.fetched[0]) == 0 {
+				r.fetched = r.fetched[1:]
+			}
+			return n, nil
+		case r.cur != nil:
+			n, err := r.cur.Read(p)
+			if err == nil {
+				return n, nil
+			}
+			if !errors.Is(err, io.EOF) {
+				r.err = err
+				r.closeCurrent()
+				return n, r.err
+			}
+			if closeErr := r.closeCurrent(); closeErr != nil {
+				r.err = closeErr
+			}
+			if n > 0 {
+				return n, nil
+			}
+		case r.next >= len(r.digests):
+			return 0, io.EOF
+		default:
+			if err := r.advance(); err != nil {
+				r.err = err
+				return 0, r.err
+			}
+		}
+	}
+}
+
+// advance readies the next blob (or window of blobs) for delivery.
+func (r *cachedMultiReader) advance() error {
+	digest := r.digests[r.next]
+	// Read a blob on its own when batching would not help: one the cache can
+	// already serve -- from disk, or by attaching to a fetch another reader
+	// started -- and one too large to hold in memory, which the per-blob path
+	// streams through a temp file instead.
+	if digest.SizeBytes > maxPopulateBytes || r.cache.cachedOrInflight(digest) {
+		reader, err := r.cache.ReaderForBlob(r.ctx, digest)
+		if err != nil {
+			return err
+		}
+		r.cur = reader
+		r.next++
+		return nil
+	}
+	return r.populate()
+}
+
+// populate fetches a window of consecutive blobs the cache does not have, in one
+// upstream read, and caches them.
+func (r *cachedMultiReader) populate() error {
+	end := r.windowEnd()
+	window := r.digests[r.next:end]
+	stream, err := r.cache.upstream.ReaderForBlobs(r.ctx, window)
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+
+	blobs := make([][]byte, 0, len(window))
+	for _, digest := range window {
+		data := make([]byte, digest.SizeBytes)
+		if _, err := io.ReadFull(stream, data); err != nil {
+			return fmt.Errorf("reading blob %s from the remote cache: %w", digest.hexHash(), err)
+		}
+		if hasher := digestHasher(digest); hasher != nil {
+			hasher.Write(data)
+			if sum := hasher.Sum(nil); !bytes.Equal(sum, digest.Hash) {
+				return fmt.Errorf("blob %s: content from remote cache hashes to %x", digest.hexHash(), sum)
+			}
+		}
+		r.cache.counters.fetches.Add(1)
+		r.cache.counters.bytesFetched.Add(digest.SizeBytes)
+		r.cache.store.put(digest, data)
+		blobs = append(blobs, data)
+	}
+
+	r.fetched = blobs
+	r.next = end
+	return nil
+}
+
+// windowEnd returns the end of the run of blobs starting at r.next that is worth
+// fetching in one request: consecutive blobs the cache cannot already serve,
+// bounded by maxPopulateBytes so a window always fits in memory and by
+// maxBatchReadDigests so a run of tiny blobs cannot make it unboundedly long.
+// advance has already vetted the blob at r.next, which is what keeps the window
+// non-empty.
+func (r *cachedMultiReader) windowEnd() int {
+	var total int64
+	end := r.next
+	for end < len(r.digests) && end-r.next < maxBatchReadDigests {
+		digest := r.digests[end]
+		if end > r.next {
+			if digest.SizeBytes > maxPopulateBytes || r.cache.cachedOrInflight(digest) {
+				break
+			}
+			if total+digest.SizeBytes > maxPopulateBytes {
+				break
+			}
+		}
+		total += digest.SizeBytes
+		end++
+	}
+	return end
+}
+
+func (r *cachedMultiReader) closeCurrent() error {
+	if r.cur == nil {
+		return nil
+	}
+	err := r.cur.Close()
+	r.cur = nil
+	return err
+}
+
+func (r *cachedMultiReader) Close() error {
+	r.next = len(r.digests)
+	r.fetched = nil
+	return r.closeCurrent()
+}
+
+// cachedOrInflight reports whether ReaderForBlob can serve the blob without
+// starting a new upstream read, either from the cache directory or by attaching
+// to a fetch that is already running.
+func (c *CachingReader) cachedOrInflight(digest Digest) bool {
+	c.mu.Lock()
+	_, inflight := c.inflight[digest.cacheKey()]
+	c.mu.Unlock()
+	return inflight || c.store.has(digest)
+}

--- a/img_tool/pkg/cas/cachemultiread_test.go
+++ b/img_tool/pkg/cas/cachemultiread_test.go
@@ -1,0 +1,209 @@
+package cas
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// batchRecordingBlobs is a BlobSource whose ReaderForBlobs records the lists it
+// was asked for, so a test can tell a batched fetch from a per-blob one.
+type batchRecordingBlobs struct {
+	*fakeBlobs
+
+	mu    sync.Mutex
+	lists [][]Digest
+}
+
+func newBatchRecordingBlobs(blobs ...[]byte) *batchRecordingBlobs {
+	return &batchRecordingBlobs{fakeBlobs: newFakeBlobs(blobs...)}
+}
+
+func (b *batchRecordingBlobs) ReaderForBlobs(ctx context.Context, digests []Digest) (io.ReadCloser, error) {
+	b.mu.Lock()
+	b.lists = append(b.lists, slices.Clone(digests))
+	b.mu.Unlock()
+
+	var buf bytes.Buffer
+	for _, digest := range digests {
+		data, err := b.fakeBlobs.ReadBlob(ctx, digest)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(data)
+	}
+	return io.NopCloser(&buf), nil
+}
+
+func (b *batchRecordingBlobs) batchLists() [][]Digest {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return slices.Clone(b.lists)
+}
+
+func readCachedBlobs(t *testing.T, c *CachingReader, digests []Digest) []byte {
+	t.Helper()
+	rc, err := c.ReaderForBlobs(context.Background(), digests)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestCachingReaderBatchesUncachedBlobs(t *testing.T) {
+	blobs := [][]byte{[]byte("one"), []byte("two"), []byte("three")}
+	source := newBatchRecordingBlobs(blobs...)
+	cache := newTestCache(t, source)
+
+	digests := make([]Digest, len(blobs))
+	for i, blob := range blobs {
+		digests[i] = blobDigest(blob)
+	}
+
+	got := readCachedBlobs(t, cache, digests)
+	if want := "onetwothree"; string(got) != want {
+		t.Fatalf("stream = %q, want %q", got, want)
+	}
+	lists := source.batchLists()
+	if len(lists) != 1 || len(lists[0]) != 3 {
+		t.Fatalf("upstream saw %v, want one list of 3 blobs", lists)
+	}
+}
+
+// A batched read populates the cache, so reading the same blobs again touches
+// upstream not at all.
+func TestCachingReaderCachesBatchedBlobs(t *testing.T) {
+	blobs := [][]byte{[]byte("alpha"), []byte("beta")}
+	source := newBatchRecordingBlobs(blobs...)
+	cache := newTestCache(t, source)
+
+	digests := []Digest{blobDigest(blobs[0]), blobDigest(blobs[1])}
+	first := readCachedBlobs(t, cache, digests)
+	second := readCachedBlobs(t, cache, digests)
+
+	if !bytes.Equal(first, second) {
+		t.Fatalf("second read = %q, want %q", second, first)
+	}
+	if lists := source.batchLists(); len(lists) != 1 {
+		t.Fatalf("upstream saw %d batched lists, want 1", len(lists))
+	}
+	for _, digest := range digests {
+		if got := source.readCount(digest); got != 1 {
+			t.Errorf("blob %s was read %d times upstream, want 1", digest.hexHash(), got)
+		}
+	}
+}
+
+// Blobs already on disk are served from there, and only the gaps are fetched --
+// as one batch each, not one request per blob.
+func TestCachingReaderBatchesOnlyTheGaps(t *testing.T) {
+	blobs := [][]byte{[]byte("aa"), []byte("bb"), []byte("cc"), []byte("dd"), []byte("ee")}
+	source := newBatchRecordingBlobs(blobs...)
+	cache := newTestCache(t, source)
+
+	digests := make([]Digest, len(blobs))
+	for i, blob := range blobs {
+		digests[i] = blobDigest(blob)
+	}
+	// Warm the cache with the middle blob so the run is split in two.
+	if _, err := cache.ReadBlob(context.Background(), digests[2]); err != nil {
+		t.Fatal(err)
+	}
+	source.lists = nil
+
+	got := readCachedBlobs(t, cache, digests)
+	if want := "aabbccddee"; string(got) != want {
+		t.Fatalf("stream = %q, want %q", got, want)
+	}
+	lists := source.batchLists()
+	if len(lists) != 2 {
+		t.Fatalf("upstream saw %d batched lists, want 2 (one on each side of the cached blob)", len(lists))
+	}
+	if len(lists[0]) != 2 || len(lists[1]) != 2 {
+		t.Fatalf("batched lists have sizes %d and %d, want 2 and 2", len(lists[0]), len(lists[1]))
+	}
+	if got := source.readCount(digests[2]); got != 1 {
+		t.Fatalf("the cached blob was read %d times upstream, want 1 (the warm-up)", got)
+	}
+}
+
+// Content that does not hash to its digest never reaches the caller.
+func TestCachingReaderRejectsCorruptBatchedContent(t *testing.T) {
+	blob := []byte("the real content")
+	source := newBatchRecordingBlobs(blob)
+	digest := blobDigest(blob)
+	source.serveInstead(digest, []byte("different content"))
+	cache := newTestCache(t, source)
+
+	rc, err := cache.ReaderForBlobs(context.Background(), []Digest{digest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	if _, err := io.ReadAll(rc); err == nil || !strings.Contains(err.Error(), "hashes to") {
+		t.Fatalf("error = %v, want a content mismatch", err)
+	}
+}
+
+func TestCachingReaderMultiReadSkipsEmptyBlobs(t *testing.T) {
+	blob := []byte("content")
+	source := newBatchRecordingBlobs(blob)
+	cache := newTestCache(t, source)
+
+	digests := []Digest{blobDigest(nil), blobDigest(blob)}
+	if got := readCachedBlobs(t, cache, digests); string(got) != "content" {
+		t.Fatalf("stream = %q, want %q", got, "content")
+	}
+}
+
+// A blob too large to hold in memory takes the per-blob path, which streams it
+// through a temp file, rather than being buffered by a batched fetch.
+func TestCachingReaderStreamsLargeBlobsInsteadOfBatching(t *testing.T) {
+	small := []byte("small")
+	large := bytes.Repeat([]byte("L"), maxPopulateBytes+1)
+	source := newBatchRecordingBlobs(small, large)
+	cache := newTestCache(t, source)
+
+	digests := []Digest{blobDigest(small), blobDigest(large), blobDigest(small)}
+	got := readCachedBlobs(t, cache, digests)
+	if want := len(small)*2 + len(large); len(got) != want {
+		t.Fatalf("stream is %d bytes, want %d", len(got), want)
+	}
+	for _, list := range source.batchLists() {
+		for _, digest := range list {
+			if digest.SizeBytes > maxPopulateBytes {
+				t.Fatalf("the %d byte blob was fetched as part of a batch", digest.SizeBytes)
+			}
+		}
+	}
+}
+
+// An upstream failure is reported and stays reported.
+func TestCachingReaderMultiReadPropagatesUpstreamFailure(t *testing.T) {
+	blob := []byte("content")
+	source := newBatchRecordingBlobs(blob)
+	source.openErr = errors.New("upstream is down")
+	cache := newTestCache(t, source)
+
+	rc, err := cache.ReaderForBlobs(context.Background(), []Digest{blobDigest(blob)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	if _, err := io.ReadAll(rc); err == nil || !strings.Contains(err.Error(), "upstream is down") {
+		t.Fatalf("error = %v, want the upstream failure", err)
+	}
+	if _, err := rc.Read(make([]byte, 1)); err == nil || !strings.Contains(err.Error(), "upstream is down") {
+		t.Fatalf("error after failure = %v, want the upstream failure again", err)
+	}
+}

--- a/img_tool/pkg/cas/cachestore.go
+++ b/img_tool/pkg/cas/cachestore.go
@@ -302,6 +302,31 @@ func (s *diskStore) finalize(tempPath string, d Digest) error {
 	return nil
 }
 
+// put stores a blob that is already in memory. It is the whole-blob counterpart
+// of the createTemp/writeAll/finalize dance a streaming fetch does, for callers
+// that read a blob in one piece (a batched read). Caching is best effort: a
+// failure here costs the caching of one blob and is not reported.
+func (s *diskStore) put(d Digest, data []byte) {
+	f, err := s.createTemp(d.SizeBytes)
+	if err != nil {
+		if !errors.Is(err, errDiskCacheDisabled) {
+			s.disable(err)
+		}
+		return
+	}
+	tempPath := f.Name()
+	writeErr := s.writeAll(f, data)
+	f.Close()
+	if writeErr != nil {
+		s.disable(writeErr)
+		s.discard(tempPath, d.SizeBytes)
+		return
+	}
+	if err := s.finalize(tempPath, d); err != nil && isNoSpace(err) {
+		s.disable(err)
+	}
+}
+
 // writeAll writes p to f, making room by evicting cached blobs when the file
 // system reports it is out of space. The bytes already written stay valid, so a
 // retry never needs to re-fetch anything.

--- a/img_tool/pkg/cas/multiread.go
+++ b/img_tool/pkg/cas/multiread.go
@@ -1,0 +1,279 @@
+package cas
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"google.golang.org/grpc/status"
+
+	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
+)
+
+// maxBatchReadDigests bounds how many digests one BatchReadBlobs request names,
+// independently of the server's byte limit. A compact stream can reference tens
+// of thousands of tiny blobs, and a request naming all of them would be a very
+// large message for a server that only advertised a limit on the bytes it
+// returns.
+const maxBatchReadDigests = 1024
+
+// batchReadEntryOverhead is what one blob costs a BatchReadBlobs exchange beyond
+// its own bytes: in the request a Digest (a 64-character hex hash, a size and
+// their field tags and length delimiters, ~75 bytes), and in the response that
+// same Digest again inside a Response entry, plus the entry's and the data
+// field's own tags and delimiters. 128 bytes rounds that up.
+//
+// batchPayloadBudget already holds back batchFramingHeadroom for framing, but
+// that reservation is a fixed 1 KiB sized for a request naming a single blob.
+// Framing on a batch scales with the number of blobs -- a thousand of them spend
+// eighty times the reservation -- so a batch charges each blob its own share as
+// well, which keeps the message inside the transport limit however small the
+// blobs are.
+const batchReadEntryOverhead = 128
+
+// ReaderForBlobs returns a reader over the concatenation of the given blobs, in
+// the order requested. Reading it start to finish yields exactly what reading
+// each blob with [CAS.ReaderForBlob] in turn would, and empty blobs contribute
+// nothing.
+//
+// Knowing the whole list up front is what makes it fast: consecutive blobs small
+// enough to batch are read with a single BatchReadBlobs request holding as many
+// of them as the server's MaxBatchTotalSizeBytes allows, so a caller reading
+// thousands of small blobs pays a round trip per few megabytes rather than one
+// per blob. Blobs too large to batch are read with ByteStream, one at a time, as
+// before.
+//
+// Reads happen as the returned stream is consumed, so memory stays bounded by
+// one batch (at most MaxBatchTotalSizeBytes) no matter how long the list is.
+// The reader is not safe for concurrent use.
+func (c *CAS) ReaderForBlobs(ctx context.Context, digests []Digest) (io.ReadCloser, error) {
+	if len(digests) == 0 {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+	// One BatchReadBlobs request carries a single digest function, and mixing
+	// algorithms in one stream has no use here.
+	for _, d := range digests {
+		if !c.capabilities.supportedDigestFunction(d.algorithm) {
+			return nil, fmt.Errorf("unsupported digest algorithm: %s", d.algorithm)
+		}
+		if d.algorithm != digests[0].algorithm {
+			return nil, fmt.Errorf("all digests must use the same algorithm: %s != %s", d.algorithm, digests[0].algorithm)
+		}
+	}
+	// Drop empty blobs: they contribute no bytes, and keeping them would split a
+	// batch in two for nothing.
+	wanted := make([]Digest, 0, len(digests))
+	for _, d := range digests {
+		if d.SizeBytes > 0 {
+			wanted = append(wanted, d)
+		}
+	}
+	return &multiBlobReader{owner: c, ctx: ctx, digests: wanted}, nil
+}
+
+// multiBlobReader delivers a list of blobs as one stream, fetching them in
+// batches as the consumer works through it.
+type multiBlobReader struct {
+	owner   *CAS
+	ctx     context.Context
+	digests []Digest
+
+	next   int           // index of the next digest to fetch
+	batch  [][]byte      // undelivered blobs of the current batch, in order
+	stream io.ReadCloser // ByteStream read of a blob too large to batch
+	err    error         // sticky: the stream delivers nothing after a failure
+}
+
+func (r *multiBlobReader) Read(p []byte) (int, error) {
+	for {
+		if r.err != nil {
+			return 0, r.err
+		}
+		switch {
+		case len(r.batch) > 0:
+			n := copy(p, r.batch[0])
+			r.batch[0] = r.batch[0][n:]
+			if len(r.batch[0]) == 0 {
+				r.batch = r.batch[1:]
+			}
+			return n, nil
+		case r.stream != nil:
+			n, err := r.stream.Read(p)
+			if err == nil {
+				return n, nil
+			}
+			if !errors.Is(err, io.EOF) {
+				r.err = err
+				r.closeStream()
+				return n, r.err
+			}
+			if closeErr := r.closeStream(); closeErr != nil {
+				r.err = closeErr
+			}
+			if n > 0 {
+				return n, nil
+			}
+		case r.next >= len(r.digests):
+			return 0, io.EOF
+		default:
+			if err := r.fill(); err != nil {
+				r.err = err
+				return 0, r.err
+			}
+		}
+	}
+}
+
+// fill fetches the next blob or batch of blobs.
+func (r *multiBlobReader) fill() error {
+	digest := r.digests[r.next]
+	if !r.batchable(digest) {
+		stream, err := r.owner.streamReadOne(r.ctx, digest)
+		if err != nil {
+			return err
+		}
+		r.stream = stream
+		r.next++
+		return nil
+	}
+	end := r.batchEnd()
+	blobs, err := r.owner.batchRead(r.ctx, r.digests[r.next:end])
+	if err != nil {
+		return err
+	}
+	r.batch = blobs
+	r.next = end
+	return nil
+}
+
+// batchable reports whether a blob fits in a batch at all, framing included. A
+// blob that does not is read with ByteStream instead. batchEnd relies on this
+// being the same test it applies to the first digest of a run, so that a run is
+// never empty.
+func (r *multiBlobReader) batchable(digest Digest) bool {
+	return digest.SizeBytes+batchReadEntryOverhead <= r.owner.capabilities.MaxBatchTotalSizeBytes
+}
+
+// batchEnd returns the end of the run of digests starting at r.next that fits
+// into one BatchReadBlobs request. Each blob is charged its framing as well as
+// its bytes (see batchReadEntryOverhead). fill only calls it for a digest that
+// is batchable on its own, so the run is never empty.
+func (r *multiBlobReader) batchEnd() int {
+	limit := r.owner.capabilities.MaxBatchTotalSizeBytes
+	var total int64
+	end := r.next
+	for end < len(r.digests) && end-r.next < maxBatchReadDigests {
+		cost := r.digests[end].SizeBytes + batchReadEntryOverhead
+		if cost > limit || total+cost > limit {
+			break
+		}
+		total += cost
+		end++
+	}
+	return end
+}
+
+func (r *multiBlobReader) closeStream() error {
+	if r.stream == nil {
+		return nil
+	}
+	err := r.stream.Close()
+	r.stream = nil
+	return err
+}
+
+func (r *multiBlobReader) Close() error {
+	r.next = len(r.digests)
+	r.batch = nil
+	return r.closeStream()
+}
+
+// batchRead reads a run of blobs with a single BatchReadBlobs request and
+// returns their contents in request order.
+func (c *CAS) batchRead(ctx context.Context, digests []Digest) ([][]byte, error) {
+	// The same blob may be referenced more than once in a stream; ask for it once
+	// and hand out the bytes twice.
+	unique := make([]*remoteexecution_proto.Digest, 0, len(digests))
+	seen := make(map[string]struct{}, len(digests))
+	var total int64
+	for _, d := range digests {
+		total += d.SizeBytes
+		if _, ok := seen[d.hexHash()]; ok {
+			continue
+		}
+		seen[d.hexHash()] = struct{}{}
+		unique = append(unique, d.protoDigest())
+	}
+	request := &remoteexecution_proto.BatchReadBlobsRequest{
+		InstanceName:   c.instanceName,
+		Digests:        unique,
+		DigestFunction: digests[0].protoDigestFunction(),
+	}
+
+	r := c.retry.start(batchReadDescription(digests, unique, total))
+	for {
+		blobs, err := c.peer(r.attempt).batchReadOnce(ctx, request, digests)
+		if err == nil {
+			return blobs, nil
+		}
+		if giveUp := r.next(ctx, err); giveUp != nil {
+			return nil, fmt.Errorf("failed to read blob(s): %w", casErr(giveUp))
+		}
+	}
+}
+
+// batchReadDescription names a batch read in retry warnings and in the final
+// error.
+func batchReadDescription(digests []Digest, unique []*remoteexecution_proto.Digest, total int64) string {
+	if len(unique) == 1 {
+		return fmt.Sprintf("reading blob %s (%d bytes) from the remote cache", digests[0].hexHash(), digests[0].SizeBytes)
+	}
+	return fmt.Sprintf("reading %d blobs (%d bytes) from the remote cache", len(unique), total)
+}
+
+// batchReadOnce is one BatchReadBlobs call. A transient per-blob status is
+// returned as a status error, so the retry loop treats it like a transient
+// call-level failure and repeats the whole request: the spec has BatchReadBlobs
+// report each blob's outcome individually, and re-reading a content-addressed
+// blob is always safe.
+//
+// Responses are matched to requests by digest rather than by position: the spec
+// does not promise an order, and a request that asked for a duplicated blob only
+// once still has to fill both of its places in the result.
+func (c *CAS) batchReadOnce(ctx context.Context, request *remoteexecution_proto.BatchReadBlobsRequest, digests []Digest) ([][]byte, error) {
+	callCtx, cancel := c.callContext(ctx)
+	defer cancel()
+	resp, err := c.casClient.BatchReadBlobs(callCtx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	byHash := make(map[string][]byte, len(resp.Responses))
+	for _, blob := range resp.Responses {
+		if st := blob.Status; st != nil && st.Code != 0 {
+			return nil, status.ErrorProto(st)
+		}
+		if blob.Digest == nil {
+			return nil, errors.New("BatchReadBlobs response entry has no digest")
+		}
+		if blob.Compressor != remoteexecution_proto.Compressor_IDENTITY {
+			return nil, fmt.Errorf("blob %s: remote cache returned %s-compressed data, which was not requested", blob.Digest.Hash, blob.Compressor)
+		}
+		byHash[blob.Digest.Hash] = blob.Data
+	}
+
+	blobs := make([][]byte, len(digests))
+	for i, d := range digests {
+		data, ok := byHash[d.hexHash()]
+		if !ok {
+			return nil, fmt.Errorf("blob %s: missing from the BatchReadBlobs response", d.hexHash())
+		}
+		if int64(len(data)) != d.SizeBytes {
+			return nil, fmt.Errorf("blob %s: remote cache returned %d bytes, expected %d", d.hexHash(), len(data), d.SizeBytes)
+		}
+		blobs[i] = data
+	}
+	return blobs, nil
+}

--- a/img_tool/pkg/cas/multiread_test.go
+++ b/img_tool/pkg/cas/multiread_test.go
@@ -1,0 +1,441 @@
+package cas
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
+)
+
+// batchCASClient answers BatchReadBlobs from memory and records the digest
+// lists it was asked for, so a test can see how a read was split into requests.
+type batchCASClient struct {
+	blobs map[string][]byte // hex hash -> content
+
+	requests [][]string // hex hashes per BatchReadBlobs call, in order
+	// reorder returns responses in reverse request order, which the spec allows.
+	reorder bool
+	// statusFor overrides the per-blob status of a hash.
+	statusFor map[string]error
+	// dataFor overrides the bytes returned for a hash.
+	dataFor map[string][]byte
+	// omit drops a hash from the response entirely.
+	omit map[string]bool
+	// compressor is reported on every response entry.
+	compressor remoteexecution_proto.Compressor_Value
+}
+
+func newBatchCASClient(blobs ...[]byte) *batchCASClient {
+	c := &batchCASClient{blobs: make(map[string][]byte)}
+	for _, blob := range blobs {
+		sum := sha256.Sum256(blob)
+		c.blobs[hex.EncodeToString(sum[:])] = blob
+	}
+	return c
+}
+
+func (c *batchCASClient) digest(blob []byte) Digest {
+	sum := sha256.Sum256(blob)
+	return SHA256(sum[:], int64(len(blob)))
+}
+
+func (c *batchCASClient) BatchReadBlobs(_ context.Context, in *remoteexecution_proto.BatchReadBlobsRequest, _ ...grpc.CallOption) (*remoteexecution_proto.BatchReadBlobsResponse, error) {
+	asked := make([]string, 0, len(in.Digests))
+	for _, d := range in.Digests {
+		asked = append(asked, d.Hash)
+	}
+	c.requests = append(c.requests, asked)
+
+	var responses []*remoteexecution_proto.BatchReadBlobsResponse_Response
+	for _, d := range in.Digests {
+		if c.omit[d.Hash] {
+			continue
+		}
+		response := &remoteexecution_proto.BatchReadBlobsResponse_Response{Digest: d, Compressor: c.compressor}
+		if err, ok := c.statusFor[d.Hash]; ok {
+			response.Status = status.Convert(err).Proto()
+		} else if data, ok := c.dataFor[d.Hash]; ok {
+			response.Data = data
+		} else {
+			response.Data = c.blobs[d.Hash]
+		}
+		responses = append(responses, response)
+	}
+	if c.reorder {
+		slices.Reverse(responses)
+	}
+	return &remoteexecution_proto.BatchReadBlobsResponse{Responses: responses}, nil
+}
+
+func (c *batchCASClient) FindMissingBlobs(context.Context, *remoteexecution_proto.FindMissingBlobsRequest, ...grpc.CallOption) (*remoteexecution_proto.FindMissingBlobsResponse, error) {
+	panic("not implemented")
+}
+
+func (c *batchCASClient) BatchUpdateBlobs(context.Context, *remoteexecution_proto.BatchUpdateBlobsRequest, ...grpc.CallOption) (*remoteexecution_proto.BatchUpdateBlobsResponse, error) {
+	panic("not implemented")
+}
+
+func (c *batchCASClient) GetTree(context.Context, *remoteexecution_proto.GetTreeRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[remoteexecution_proto.GetTreeResponse], error) {
+	panic("not implemented")
+}
+
+func (c *batchCASClient) SplitBlob(context.Context, *remoteexecution_proto.SplitBlobRequest, ...grpc.CallOption) (*remoteexecution_proto.SplitBlobResponse, error) {
+	panic("not implemented")
+}
+
+func (c *batchCASClient) SpliceBlob(context.Context, *remoteexecution_proto.SpliceBlobRequest, ...grpc.CallOption) (*remoteexecution_proto.SpliceBlobResponse, error) {
+	panic("not implemented")
+}
+
+// smallBlobs returns n distinct blobs of the given size.
+func smallBlobs(n, size int) [][]byte {
+	blobs := make([][]byte, n)
+	for i := range blobs {
+		blob := bytes.Repeat([]byte{byte(i), byte(i >> 8)}, size/2)
+		blobs[i] = blob
+	}
+	return blobs
+}
+
+func digestsOf(c *batchCASClient, blobs [][]byte) []Digest {
+	digests := make([]Digest, len(blobs))
+	for i, blob := range blobs {
+		digests[i] = c.digest(blob)
+	}
+	return digests
+}
+
+// readBlobs reads the whole concatenated stream for digests.
+func readBlobs(t *testing.T, c *CAS, digests []Digest) []byte {
+	t.Helper()
+	rc, err := c.ReaderForBlobs(context.Background(), digests)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// The point of the whole exercise: many small blobs come back in a handful of
+// requests instead of one per blob.
+func TestReaderForBlobsBatchesSmallBlobs(t *testing.T) {
+	blobs := smallBlobs(300, 1000)
+	client := newBatchCASClient(blobs...)
+	c := testCAS(nil, client)
+	// 1000-byte blobs at 1128 apiece once framing is charged, 100 KiB per
+	// batch: 90 blobs per request, so 300 of them take 4.
+	c.capabilities.MaxBatchTotalSizeBytes = 100 * 1024
+
+	got := readBlobs(t, c, digestsOf(client, blobs))
+
+	if want := bytes.Join(blobs, nil); !bytes.Equal(got, want) {
+		t.Fatalf("stream is %d bytes, want %d", len(got), len(want))
+	}
+	if len(client.requests) != 4 {
+		t.Fatalf("made %d BatchReadBlobs requests, want 4", len(client.requests))
+	}
+	for i, request := range client.requests {
+		var framed int64
+		for _, hash := range request {
+			framed += int64(len(client.blobs[hash])) + batchReadEntryOverhead
+		}
+		if framed > c.capabilities.MaxBatchTotalSizeBytes {
+			t.Errorf("request %d costs %d bytes framed, over the %d byte budget", i, framed, c.capabilities.MaxBatchTotalSizeBytes)
+		}
+	}
+}
+
+// Framing on a batch scales with the number of blobs, so each blob is charged
+// its own share rather than relying on the fixed headroom batchPayloadBudget
+// holds back. A budget that fits ten blobs on payload alone fits fewer.
+func TestReaderForBlobsReservesPerBlobFraming(t *testing.T) {
+	const size = 1000
+	blobs := smallBlobs(10, size)
+	client := newBatchCASClient(blobs...)
+	c := testCAS(nil, client)
+	// Exactly ten blobs' worth of payload, and room for four blobs' framing.
+	c.capabilities.MaxBatchTotalSizeBytes = 10*size + 4*batchReadEntryOverhead
+
+	readBlobs(t, c, digestsOf(client, blobs))
+
+	if len(client.requests) < 2 {
+		t.Fatalf("made %d requests; framing was not charged against the budget", len(client.requests))
+	}
+	want := int(c.capabilities.MaxBatchTotalSizeBytes / (size + batchReadEntryOverhead))
+	if got := len(client.requests[0]); got != want {
+		t.Fatalf("first request held %d blobs, want %d", got, want)
+	}
+}
+
+// A blob that fits the budget on payload alone but not once its framing is
+// charged is streamed rather than batched. Getting this wrong would leave
+// batchEnd with an empty run.
+func TestReaderForBlobsStreamsABlobThatOnlyFitsWithoutFraming(t *testing.T) {
+	const limit = 4096
+	blob := testBlob(limit) // exactly the budget: over it once framed
+	client := newBatchCASClient(blob)
+	byteStream := &fakeByteStreamClient{blob: blob, chunkSize: 1024}
+	c := testCAS(byteStream, client)
+	c.capabilities.MaxBatchTotalSizeBytes = limit
+
+	got := readBlobs(t, c, []Digest{client.digest(blob)})
+
+	if !bytes.Equal(got, blob) {
+		t.Fatal("stream does not match the blob")
+	}
+	if len(client.requests) != 0 {
+		t.Fatalf("made %d BatchReadBlobs requests for a blob that does not fit framed", len(client.requests))
+	}
+	if byteStream.conns != 1 {
+		t.Fatalf("opened %d ByteStream reads, want 1", byteStream.conns)
+	}
+}
+
+func TestReaderForBlobsCapsTheDigestCount(t *testing.T) {
+	blobs := smallBlobs(maxBatchReadDigests+10, 2)
+	client := newBatchCASClient(blobs...)
+	c := testCAS(nil, client)
+
+	readBlobs(t, c, digestsOf(client, blobs))
+
+	if len(client.requests) != 2 {
+		t.Fatalf("made %d BatchReadBlobs requests, want 2", len(client.requests))
+	}
+	if got := len(client.requests[0]); got != maxBatchReadDigests {
+		t.Fatalf("first request asked for %d digests, want %d", got, maxBatchReadDigests)
+	}
+}
+
+// A blob too big for a batch is streamed on its own, and the blobs around it
+// still batch.
+func TestReaderForBlobsStreamsLargeBlobs(t *testing.T) {
+	small := smallBlobs(4, 100)
+	large := testBlob(4096)
+	client := newBatchCASClient(append(slices.Clone(small), large)...)
+	byteStream := &fakeByteStreamClient{blob: large, chunkSize: 512}
+	c := testCAS(byteStream, client)
+	c.capabilities.MaxBatchTotalSizeBytes = 1024
+
+	order := [][]byte{small[0], small[1], large, small[2], small[3]}
+	got := readBlobs(t, c, digestsOf(client, order))
+
+	if want := bytes.Join(order, nil); !bytes.Equal(got, want) {
+		t.Fatal("stream does not match the requested blobs in order")
+	}
+	if len(client.requests) != 2 {
+		t.Fatalf("made %d BatchReadBlobs requests, want 2 (one per run of small blobs)", len(client.requests))
+	}
+	if byteStream.conns != 1 {
+		t.Fatalf("opened %d ByteStream reads, want 1", byteStream.conns)
+	}
+}
+
+// The spec does not promise a response order, so responses are matched by
+// digest.
+func TestReaderForBlobsMatchesResponsesByDigest(t *testing.T) {
+	blobs := smallBlobs(8, 100)
+	client := newBatchCASClient(blobs...)
+	client.reorder = true
+	c := testCAS(nil, client)
+
+	got := readBlobs(t, c, digestsOf(client, blobs))
+
+	if want := bytes.Join(blobs, nil); !bytes.Equal(got, want) {
+		t.Fatal("a reordered response reordered the stream")
+	}
+}
+
+// A blob referenced twice is requested once and delivered twice.
+func TestReaderForBlobsDeduplicatesWithinARequest(t *testing.T) {
+	blobs := smallBlobs(2, 100)
+	client := newBatchCASClient(blobs...)
+	c := testCAS(nil, client)
+
+	order := [][]byte{blobs[0], blobs[1], blobs[0]}
+	got := readBlobs(t, c, digestsOf(client, order))
+
+	if want := bytes.Join(order, nil); !bytes.Equal(got, want) {
+		t.Fatal("a repeated blob was not delivered twice")
+	}
+	if len(client.requests) != 1 {
+		t.Fatalf("made %d requests, want 1", len(client.requests))
+	}
+	if got := len(client.requests[0]); got != 2 {
+		t.Fatalf("asked for %d digests, want 2 (the repeat is asked for once)", got)
+	}
+}
+
+// An empty blob contributes nothing and costs no request.
+func TestReaderForBlobsSkipsEmptyBlobs(t *testing.T) {
+	blobs := smallBlobs(2, 100)
+	client := newBatchCASClient(blobs...)
+	c := testCAS(nil, client)
+
+	digests := []Digest{client.digest(blobs[0]), SHA256(sha256Of(nil), 0), client.digest(blobs[1])}
+	got := readBlobs(t, c, digests)
+
+	if want := append(slices.Clone(blobs[0]), blobs[1]...); !bytes.Equal(got, want) {
+		t.Fatal("an empty blob changed the stream")
+	}
+	if len(client.requests) != 1 {
+		t.Fatalf("made %d requests, want 1 (an empty blob must not split the batch)", len(client.requests))
+	}
+}
+
+func TestReaderForBlobsEmptyList(t *testing.T) {
+	client := newBatchCASClient()
+	c := testCAS(nil, client)
+
+	if got := readBlobs(t, c, nil); len(got) != 0 {
+		t.Fatalf("stream = %q, want empty", got)
+	}
+	if len(client.requests) != 0 {
+		t.Fatalf("made %d requests for an empty list", len(client.requests))
+	}
+}
+
+func TestReaderForBlobsRejectsAMissingResponseEntry(t *testing.T) {
+	blobs := smallBlobs(3, 100)
+	client := newBatchCASClient(blobs...)
+	missing := client.digest(blobs[1])
+	client.omit = map[string]bool{missing.hexHash(): true}
+	c := testCAS(nil, client)
+
+	rc, err := c.ReaderForBlobs(context.Background(), digestsOf(client, blobs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	if _, err := io.ReadAll(rc); err == nil || !strings.Contains(err.Error(), "missing from the BatchReadBlobs response") {
+		t.Fatalf("error = %v, want it to report the missing entry", err)
+	}
+}
+
+func TestReaderForBlobsRejectsAWrongSizedBlob(t *testing.T) {
+	blobs := smallBlobs(2, 100)
+	client := newBatchCASClient(blobs...)
+	short := client.digest(blobs[0])
+	client.dataFor = map[string][]byte{short.hexHash(): blobs[0][:10]}
+	c := testCAS(nil, client)
+
+	rc, err := c.ReaderForBlobs(context.Background(), digestsOf(client, blobs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	if _, err := io.ReadAll(rc); err == nil || !strings.Contains(err.Error(), "expected 100") {
+		t.Fatalf("error = %v, want it to report the size mismatch", err)
+	}
+}
+
+func TestReaderForBlobsRejectsCompressedData(t *testing.T) {
+	blobs := smallBlobs(1, 100)
+	client := newBatchCASClient(blobs...)
+	client.compressor = remoteexecution_proto.Compressor_ZSTD
+	c := testCAS(nil, client)
+
+	rc, err := c.ReaderForBlobs(context.Background(), digestsOf(client, blobs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	if _, err := io.ReadAll(rc); err == nil || !strings.Contains(err.Error(), "compressed data") {
+		t.Fatalf("error = %v, want it to reject the compressed response", err)
+	}
+}
+
+// A cache miss is reported per blob, and is not retried.
+func TestReaderForBlobsReportsAPerBlobStatus(t *testing.T) {
+	blobs := smallBlobs(2, 100)
+	client := newBatchCASClient(blobs...)
+	client.statusFor = map[string]error{
+		client.digest(blobs[1]).hexHash(): status.Error(codes.NotFound, "no such blob"),
+	}
+	c := testCAS(nil, client)
+
+	rc, err := c.ReaderForBlobs(context.Background(), digestsOf(client, blobs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	_, err = io.ReadAll(rc)
+	if status.Code(errors.Unwrap(err)) != codes.NotFound && !strings.Contains(err.Error(), "no such blob") {
+		t.Fatalf("error = %v, want the NotFound status", err)
+	}
+	if len(client.requests) != 1 {
+		t.Fatalf("made %d requests, want 1 (a cache miss is not retried)", len(client.requests))
+	}
+}
+
+func TestReaderForBlobsRejectsMixedAlgorithms(t *testing.T) {
+	c := testCAS(nil, newBatchCASClient())
+	c.capabilities.DigestFunctionSHA512 = true
+
+	digests := []Digest{SHA256(sha256Of([]byte("a")), 1), SHA512(sha256Of([]byte("b")), 1)}
+	if _, err := c.ReaderForBlobs(context.Background(), digests); err == nil {
+		t.Fatal("mixing digest algorithms in one stream was accepted")
+	}
+}
+
+// Closing partway through must not leave the ByteStream read of a large blob
+// open.
+func TestReaderForBlobsCloseReleasesTheStream(t *testing.T) {
+	large := testBlob(4096)
+	client := newBatchCASClient(large)
+	byteStream := &fakeByteStreamClient{blob: large, chunkSize: 128}
+	c := testCAS(byteStream, client)
+	c.capabilities.MaxBatchTotalSizeBytes = 1024
+
+	rc, err := c.ReaderForBlobs(context.Background(), []Digest{client.digest(large)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(rc, make([]byte, 64)); err != nil {
+		t.Fatal(err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := rc.Read(make([]byte, 1)); err != io.EOF || got != 0 {
+		t.Fatalf("read after Close = (%d, %v), want (0, EOF)", got, err)
+	}
+}
+
+// ReadBlob still works: the single-blob path now goes through the same batch
+// call with a one-digest request.
+func TestReadBlobStillUsesASingleDigestRequest(t *testing.T) {
+	blob := testBlob(100)
+	client := newBatchCASClient(blob)
+	c := testCAS(nil, client)
+
+	got, err := c.ReadBlob(context.Background(), client.digest(blob))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, blob) {
+		t.Fatal("ReadBlob returned the wrong content")
+	}
+	if len(client.requests) != 1 || len(client.requests[0]) != 1 {
+		t.Fatalf("requests = %v, want one request for one digest", client.requests)
+	}
+}
+
+func sha256Of(b []byte) []byte {
+	sum := sha256.Sum256(b)
+	return sum[:]
+}

--- a/img_tool/pkg/cas/pool.go
+++ b/img_tool/pkg/cas/pool.go
@@ -15,6 +15,11 @@ type BlobSource interface {
 	FindMissingBlobs(ctx context.Context, digests []Digest) ([]Digest, error)
 	ReadBlob(ctx context.Context, digest Digest) ([]byte, error)
 	ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, error)
+	// ReaderForBlobs reads a whole list of blobs as one stream: the
+	// concatenation of the blobs, in the order requested. It is what
+	// ReaderForBlob is to a single blob, and exists so that an implementation
+	// can serve many small blobs without a round trip each.
+	ReaderForBlobs(ctx context.Context, digests []Digest) (io.ReadCloser, error)
 }
 
 var (
@@ -83,6 +88,13 @@ func (p *Pool) ReadBlob(ctx context.Context, digest Digest) ([]byte, error) {
 
 func (p *Pool) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, error) {
 	return p.pick().ReaderForBlob(ctx, digest)
+}
+
+// ReaderForBlobs serves the whole list from one member, so the batches of a
+// single stream stay on one connection and arrive in order. Pooling still pays
+// off across streams: concurrent readers land on different members.
+func (p *Pool) ReaderForBlobs(ctx context.Context, digests []Digest) (io.ReadCloser, error) {
+	return p.pick().ReaderForBlobs(ctx, digests)
 }
 
 // RetryStats reports what the retry loops of every member did.

--- a/img_tool/pkg/cas/pool_test.go
+++ b/img_tool/pkg/cas/pool_test.go
@@ -32,6 +32,11 @@ func (f *fakeSource) ReaderForBlob(context.Context, Digest) (io.ReadCloser, erro
 	return io.NopCloser(strings.NewReader("")), nil
 }
 
+func (f *fakeSource) ReaderForBlobs(context.Context, []Digest) (io.ReadCloser, error) {
+	f.record()
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
 func (f *fakeSource) record() {
 	f.mu.Lock()
 	f.calls++
@@ -61,8 +66,8 @@ func TestPoolDistributesPublicMethods(t *testing.T) {
 	p := newPool(sources)
 
 	ctx := context.Background()
-	// Each iteration issues one of each read method (3 picks); 3 iterations
-	// spread 9 picks evenly across the 3 members.
+	// Each iteration issues one of each read method (4 picks); 3 iterations
+	// spread 12 picks evenly across the 3 members.
 	for range 3 {
 		if _, err := p.FindMissingBlobs(ctx, nil); err != nil {
 			t.Fatal(err)
@@ -75,11 +80,16 @@ func TestPoolDistributesPublicMethods(t *testing.T) {
 			t.Fatal(err)
 		}
 		rc.Close()
+		multi, err := p.ReaderForBlobs(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		multi.Close()
 	}
 
 	for i, m := range members {
-		if m.calls != 3 {
-			t.Errorf("member %d handled %d calls, want 3", i, m.calls)
+		if m.calls != 4 {
+			t.Errorf("member %d handled %d calls, want 4", i, m.calls)
 		}
 	}
 }

--- a/img_tool/pkg/cas/read.go
+++ b/img_tool/pkg/cas/read.go
@@ -196,44 +196,11 @@ func (c *CAS) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, 
 }
 
 func (c *CAS) batchReadOne(ctx context.Context, digest Digest) ([]byte, error) {
-	request := &remoteexecution_proto.BatchReadBlobsRequest{
-		InstanceName:   c.instanceName,
-		Digests:        []*remoteexecution_proto.Digest{digest.protoDigest()},
-		DigestFunction: digest.protoDigestFunction(),
-	}
-	r := c.retry.start(fmt.Sprintf("reading blob %s (%d bytes) from the remote cache", digest.hexHash(), digest.SizeBytes))
-	for {
-		data, err := c.peer(r.attempt).batchReadOnce(ctx, request, digest)
-		if err == nil {
-			return data, nil
-		}
-		if giveUp := r.next(ctx, err); giveUp != nil {
-			return nil, fmt.Errorf("failed to read blob: %w", casErr(giveUp))
-		}
-	}
-}
-
-// batchReadOnce is one BatchReadBlobs call for a single blob. A transient
-// per-blob status is returned as a status error, so the retry loop treats it
-// like a transient call-level failure: the spec has BatchReadBlobs report each
-// blob's outcome individually.
-func (c *CAS) batchReadOnce(ctx context.Context, request *remoteexecution_proto.BatchReadBlobsRequest, digest Digest) ([]byte, error) {
-	callCtx, cancel := c.callContext(ctx)
-	defer cancel()
-	resp, err := c.casClient.BatchReadBlobs(callCtx, request)
+	blobs, err := c.batchRead(ctx, []Digest{digest})
 	if err != nil {
 		return nil, err
 	}
-	if len(resp.Responses) != 1 {
-		return nil, errors.New("unexpected number of responses from BatchReadBlobs")
-	}
-	if st := resp.Responses[0].Status; st != nil && st.Code != 0 {
-		return nil, status.ErrorProto(st)
-	}
-	if len(resp.Responses[0].Data) != int(digest.SizeBytes) {
-		return nil, fmt.Errorf("unexpected size of blob data: got %d bytes, expected %d bytes", len(resp.Responses[0].Data), digest.SizeBytes)
-	}
-	return resp.Responses[0].Data, nil
+	return blobs[0], nil
 }
 
 func (c *CAS) streamReadOne(ctx context.Context, digest Digest) (io.ReadCloser, error) {

--- a/img_tool/pkg/compactstream/BUILD.bazel
+++ b/img_tool/pkg/compactstream/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "compactstream",
     srcs = [
+        "blobstream.go",
         "inspect.go",
         "reader.go",
         "writer.go",
@@ -18,6 +19,7 @@ go_library(
 go_test(
     name = "compactstream_test",
     srcs = [
+        "blobstream_test.go",
         "reader_test.go",
         "reconstruct_uncompressed_test.go",
         "writer_test.go",

--- a/img_tool/pkg/compactstream/blobstream.go
+++ b/img_tool/pkg/compactstream/blobstream.go
@@ -1,0 +1,173 @@
+package compactstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// BlobRequest identifies one content-addressed blob a compact stream references.
+type BlobRequest struct {
+	Digest []byte
+	Size   int64
+}
+
+// MultiBlobStore is an optional extension of [BlobStore] for stores that can
+// serve a whole list of blobs at once. ReaderForBlobs returns the concatenation
+// of the requested blobs, in request order, so reading it is indistinguishable
+// from reading each blob with ReaderForBlob in turn.
+//
+// Reconstruction hands the store the entire reference table of a layer up front,
+// which is what lets a store batch. A layer that references thousands of small
+// files costs one round trip per file when each is fetched on its own; a store
+// that sees the whole list can ask a remote CAS for many blobs per request and
+// pay a round trip per few megabytes instead.
+//
+// The result must be streamed, not materialized: the concatenation is as large
+// as the layer's file contents, so an implementation may only ever hold a
+// bounded part of it in memory.
+type MultiBlobStore interface {
+	BlobStore
+	ReaderForBlobs(ctx context.Context, requests []BlobRequest) (io.ReadCloser, error)
+}
+
+// BlobStreamPart is one part of a concatenated blob stream: a reader that
+// delivers exactly Size bytes, opened only once the stream reaches it.
+//
+// A part is one blob or a run of blobs the same source serves together --
+// whatever unit an implementation wants to fetch in one go.
+type BlobStreamPart struct {
+	Size int64
+	Open func() (io.ReadCloser, error)
+}
+
+// NewBlobStream returns a reader over the concatenation of parts. Each part is
+// opened when the stream reaches it and closed before the next one is opened, so
+// at most one part is in flight at a time. A part that ends before it delivered
+// Size bytes fails the read; bytes past Size are ignored.
+//
+// It is the plumbing behind [MultiBlobStore]: reconstruction's own fallback is
+// one part per blob, and a store that serves some blobs locally and batches the
+// rest is one part per run.
+func NewBlobStream(parts []BlobStreamPart) io.ReadCloser {
+	return &blobStream{parts: parts}
+}
+
+// blobStreamFor returns a reader over the concatenation of the requested blobs,
+// using the store's own [MultiBlobStore] implementation when it has one.
+func blobStreamFor(ctx context.Context, store BlobStore, requests []BlobRequest) (io.ReadCloser, error) {
+	if multi, ok := store.(MultiBlobStore); ok {
+		return multi.ReaderForBlobs(ctx, requests)
+	}
+	return serialBlobStream(ctx, store, requests), nil
+}
+
+// serialBlobStream is the fallback for a plain [BlobStore]: one part per blob,
+// each opened with ReaderForBlob when the stream reaches it.
+func serialBlobStream(ctx context.Context, store BlobStore, requests []BlobRequest) io.ReadCloser {
+	parts := make([]BlobStreamPart, len(requests))
+	for i, request := range requests {
+		parts[i] = BlobStreamPart{
+			Size: request.Size,
+			Open: func() (io.ReadCloser, error) {
+				return store.ReaderForBlob(ctx, request.Digest, request.Size)
+			},
+		}
+	}
+	return NewBlobStream(parts)
+}
+
+// blobStream walks a list of parts, concatenating them into one stream.
+type blobStream struct {
+	parts []BlobStreamPart
+
+	next      int           // index of the part to open next
+	cur       io.ReadCloser // the open part, nil between parts
+	remaining int64         // bytes the open part still owes us
+	err       error         // sticky: the stream delivers nothing after a failure
+}
+
+func (s *blobStream) Read(p []byte) (int, error) {
+	for {
+		if s.err != nil {
+			return 0, s.err
+		}
+		if s.cur == nil {
+			if s.next >= len(s.parts) {
+				return 0, io.EOF
+			}
+			part := s.parts[s.next]
+			s.next++
+			if part.Size <= 0 {
+				continue // an empty part contributes nothing
+			}
+			reader, err := part.Open()
+			if err != nil {
+				s.err = err
+				return 0, s.err
+			}
+			s.cur = reader
+			s.remaining = part.Size
+		}
+		if len(p) == 0 {
+			return 0, nil
+		}
+
+		// Never read past the end of the part: the reader may be shared with
+		// whatever comes after it.
+		buf := p
+		if int64(len(buf)) > s.remaining {
+			buf = buf[:s.remaining]
+		}
+		n, err := s.cur.Read(buf)
+		s.remaining -= int64(n)
+
+		switch {
+		case s.remaining == 0:
+			// The part is complete. Anything it has left over is not ours to read.
+			if closeErr := s.closeCurrent(); closeErr != nil {
+				s.err = closeErr
+			}
+		case err != nil:
+			s.err = s.partError(err)
+			s.closeCurrent()
+		}
+
+		if n > 0 {
+			return n, nil
+		}
+		if s.err != nil {
+			return 0, s.err
+		}
+		if s.cur != nil {
+			// The part returned no bytes and no error; let the caller come back
+			// rather than spinning here.
+			return 0, nil
+		}
+	}
+}
+
+// partError describes a part that failed before delivering everything it owed.
+func (s *blobStream) partError(err error) error {
+	part := s.parts[s.next-1]
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return fmt.Errorf("blob stream part %d of %d ended %d bytes short of its %d bytes: %w",
+			s.next, len(s.parts), s.remaining, part.Size, io.ErrUnexpectedEOF)
+	}
+	return fmt.Errorf("reading blob stream part %d of %d: %w", s.next, len(s.parts), err)
+}
+
+func (s *blobStream) closeCurrent() error {
+	if s.cur == nil {
+		return nil
+	}
+	err := s.cur.Close()
+	s.cur = nil
+	return err
+}
+
+func (s *blobStream) Close() error {
+	s.next = len(s.parts)
+	return s.closeCurrent()
+}

--- a/img_tool/pkg/compactstream/blobstream_test.go
+++ b/img_tool/pkg/compactstream/blobstream_test.go
@@ -1,0 +1,334 @@
+package compactstream
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// partsOf builds one part per string, each delivering exactly its bytes.
+func partsOf(opened *[]int, chunks ...string) []BlobStreamPart {
+	parts := make([]BlobStreamPart, len(chunks))
+	for i, chunk := range chunks {
+		parts[i] = BlobStreamPart{
+			Size: int64(len(chunk)),
+			Open: func() (io.ReadCloser, error) {
+				if opened != nil {
+					*opened = append(*opened, i)
+				}
+				return io.NopCloser(strings.NewReader(chunk)), nil
+			},
+		}
+	}
+	return parts
+}
+
+func TestBlobStreamConcatenatesParts(t *testing.T) {
+	stream := NewBlobStream(partsOf(nil, "alpha", "", "beta", "gamma"))
+	defer stream.Close()
+
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "alphabetagamma"; string(got) != want {
+		t.Fatalf("stream = %q, want %q", got, want)
+	}
+}
+
+func TestBlobStreamOpensPartsOnlyWhenReached(t *testing.T) {
+	var opened []int
+	stream := NewBlobStream(partsOf(&opened, "alpha", "beta", "gamma"))
+	defer stream.Close()
+
+	if len(opened) != 0 {
+		t.Fatalf("parts %v were opened before the first read", opened)
+	}
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(stream, buf); err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "alpha" {
+		t.Fatalf("read %q, want %q", buf, "alpha")
+	}
+	if len(opened) != 1 || opened[0] != 0 {
+		t.Fatalf("opened %v after reading the first part, want [0]", opened)
+	}
+}
+
+// A part must not be read past its declared size: the same reader may be
+// serving whatever comes next.
+func TestBlobStreamStopsAtThePartBoundary(t *testing.T) {
+	shared := strings.NewReader("firstsecond")
+	parts := []BlobStreamPart{
+		{Size: 5, Open: func() (io.ReadCloser, error) { return io.NopCloser(shared), nil }},
+		{Size: 6, Open: func() (io.ReadCloser, error) { return io.NopCloser(shared), nil }},
+	}
+	stream := NewBlobStream(parts)
+	defer stream.Close()
+
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "firstsecond"; string(got) != want {
+		t.Fatalf("stream = %q, want %q", got, want)
+	}
+}
+
+func TestBlobStreamRejectsAShortPart(t *testing.T) {
+	parts := []BlobStreamPart{
+		{Size: 5, Open: func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader("abc")), nil }},
+	}
+	stream := NewBlobStream(parts)
+	defer stream.Close()
+
+	_, err := io.ReadAll(stream)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("error = %v, want an unexpected-EOF error", err)
+	}
+}
+
+func TestBlobStreamReportsAnOpenFailureOnce(t *testing.T) {
+	want := errors.New("no such blob")
+	parts := []BlobStreamPart{
+		{Size: 3, Open: func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader("abc")), nil }},
+		{Size: 3, Open: func() (io.ReadCloser, error) { return nil, want }},
+	}
+	stream := NewBlobStream(parts)
+	defer stream.Close()
+
+	if _, err := io.ReadAll(stream); !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+	// The failure is sticky: a second read reports it again rather than moving on.
+	if _, err := stream.Read(make([]byte, 1)); !errors.Is(err, want) {
+		t.Fatalf("error after failure = %v, want %v", err, want)
+	}
+}
+
+func TestBlobStreamClosesEachPart(t *testing.T) {
+	var closed int
+	part := func(content string) BlobStreamPart {
+		return BlobStreamPart{
+			Size: int64(len(content)),
+			Open: func() (io.ReadCloser, error) {
+				return &countingCloser{Reader: strings.NewReader(content), closed: &closed}, nil
+			},
+		}
+	}
+	stream := NewBlobStream([]BlobStreamPart{part("one"), part("two")})
+	if _, err := io.ReadAll(stream); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if closed != 2 {
+		t.Fatalf("closed %d parts, want 2", closed)
+	}
+}
+
+// Closing early must release the open part and not open any more.
+func TestBlobStreamCloseStopsEarly(t *testing.T) {
+	var opened []int
+	var closed int
+	parts := partsOf(&opened, "alpha", "beta")
+	parts[0].Open = func() (io.ReadCloser, error) {
+		opened = append(opened, 0)
+		return &countingCloser{Reader: strings.NewReader("alpha"), closed: &closed}, nil
+	}
+	stream := NewBlobStream(parts)
+
+	if _, err := io.ReadFull(stream, make([]byte, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if closed != 1 {
+		t.Fatalf("closed %d parts, want 1", closed)
+	}
+	if _, err := io.ReadAll(stream); err != nil {
+		t.Fatal(err)
+	}
+	if len(opened) != 1 {
+		t.Fatalf("opened %v, want only the first part", opened)
+	}
+}
+
+// multiMapBlobStore serves blobs from memory and records the request lists it
+// was handed, so a test can tell how reconstruction asked for them.
+type multiMapBlobStore struct {
+	blobs mapBlobStore
+
+	multiCalls  [][]BlobRequest
+	singleReads int
+}
+
+func (s *multiMapBlobStore) ReaderForBlob(ctx context.Context, digest []byte, size int64) (io.ReadCloser, error) {
+	s.singleReads++
+	return s.blobs.ReaderForBlob(ctx, digest, size)
+}
+
+func (s *multiMapBlobStore) ReaderForBlobs(ctx context.Context, requests []BlobRequest) (io.ReadCloser, error) {
+	s.multiCalls = append(s.multiCalls, requests)
+	parts := make([]BlobStreamPart, len(requests))
+	for i, request := range requests {
+		parts[i] = BlobStreamPart{
+			Size: request.Size,
+			Open: func() (io.ReadCloser, error) {
+				return s.blobs.ReaderForBlob(ctx, request.Digest, request.Size)
+			},
+		}
+	}
+	return NewBlobStream(parts), nil
+}
+
+// buildBlobbyStream builds a compact stream of n small blobs separated by
+// one-byte gaps, and returns the index together with the bytes it reconstructs
+// to.
+func buildBlobbyStream(store mapBlobStore, n int) (index, want []byte) {
+	var refs []rawRef
+	var stream []byte
+	var offset uint64
+	for i := range n {
+		gap := []byte{byte(i)}
+		blob := bytes.Repeat([]byte{byte(i), byte(i >> 8)}, 8)
+		digest := store.put(blob)
+
+		stream = append(stream, gap...)
+		want = append(want, gap...)
+		offset += uint64(len(gap))
+		refs = append(refs, rawRef{offset: offset, digest: digest, size: uint64(len(blob))})
+		want = append(want, blob...)
+		offset += uint64(len(blob))
+	}
+	return buildRawCompactStream(refs, stream), want
+}
+
+// Reconstruction must hand a MultiBlobStore the whole reference table in one
+// call: seeing every blob it will need is what lets the store batch them.
+func TestReconstructAsksAMultiBlobStoreForTheWholeRefTable(t *testing.T) {
+	store := &multiMapBlobStore{blobs: mapBlobStore{}}
+	const refCount = 200
+	index, want := buildBlobbyStream(store.blobs, refCount)
+
+	var out bytes.Buffer
+	if err := Reconstruct(context.Background(), bytes.NewReader(index), store, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(out.Bytes(), want) {
+		t.Fatal("reconstruction through a MultiBlobStore changed the output")
+	}
+	if len(store.multiCalls) != 1 {
+		t.Fatalf("ReaderForBlobs was called %d times, want 1", len(store.multiCalls))
+	}
+	if got := len(store.multiCalls[0]); got != refCount {
+		t.Fatalf("ReaderForBlobs was asked for %d blobs, want %d", got, refCount)
+	}
+	if store.singleReads != 0 {
+		t.Fatalf("%d blobs were read one at a time", store.singleReads)
+	}
+}
+
+// The same stream must reconstruct identically whether the store can serve a
+// list or only one blob at a time.
+func TestReconstructMatchesBetweenSingleAndMultiBlobStores(t *testing.T) {
+	blobs := mapBlobStore{}
+	index, want := buildBlobbyStream(blobs, 64)
+
+	var serial, multi bytes.Buffer
+	if err := Reconstruct(context.Background(), bytes.NewReader(index), blobs, &serial); err != nil {
+		t.Fatal(err)
+	}
+	if err := Reconstruct(context.Background(), bytes.NewReader(index), &multiMapBlobStore{blobs: blobs}, &multi); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(serial.Bytes(), want) {
+		t.Fatal("serial reconstruction does not match the expected bytes")
+	}
+	if !bytes.Equal(multi.Bytes(), serial.Bytes()) {
+		t.Fatal("multi-blob reconstruction differs from the serial one")
+	}
+}
+
+// Whatever the layout of gaps and blobs, the two kinds of store must produce
+// the same bytes: the only thing a MultiBlobStore changes is how the blobs are
+// fetched.
+func TestReconstructMatchesForRandomLayouts(t *testing.T) {
+	for seed := range int64(50) {
+		rng := rand.New(rand.NewSource(seed))
+		blobs := mapBlobStore{}
+		var refs []rawRef
+		var stream, want []byte
+		var offset uint64
+
+		for range rng.Intn(60) {
+			gap := make([]byte, rng.Intn(5))
+			rng.Read(gap)
+			stream = append(stream, gap...)
+			want = append(want, gap...)
+			offset += uint64(len(gap))
+
+			blob := make([]byte, rng.Intn(3000))
+			rng.Read(blob)
+			digest := blobs.put(blob)
+			refs = append(refs, rawRef{offset: offset, digest: digest, size: uint64(len(blob))})
+			want = append(want, blob...)
+			offset += uint64(len(blob))
+		}
+		tail := make([]byte, rng.Intn(16))
+		rng.Read(tail)
+		stream = append(stream, tail...)
+		want = append(want, tail...)
+
+		index := buildRawCompactStream(refs, stream)
+		var serial, multi bytes.Buffer
+		if err := Reconstruct(context.Background(), bytes.NewReader(index), blobs, &serial); err != nil {
+			t.Fatalf("seed %d, serial: %v", seed, err)
+		}
+		if err := Reconstruct(context.Background(), bytes.NewReader(index), &multiMapBlobStore{blobs: blobs}, &multi); err != nil {
+			t.Fatalf("seed %d, multi: %v", seed, err)
+		}
+		if !bytes.Equal(serial.Bytes(), want) {
+			t.Fatalf("seed %d: serial reconstruction does not match the expected bytes", seed)
+		}
+		if !bytes.Equal(multi.Bytes(), serial.Bytes()) {
+			t.Fatalf("seed %d: multi-blob reconstruction differs from the serial one", seed)
+		}
+	}
+}
+
+func TestReconstructReportsAMultiBlobStoreFailure(t *testing.T) {
+	blobs := mapBlobStore{}
+	index, _ := buildBlobbyStream(blobs, 4)
+	// Drop one blob so the store cannot serve the whole list.
+	for key := range blobs {
+		delete(blobs, key)
+		break
+	}
+
+	var out bytes.Buffer
+	err := Reconstruct(context.Background(), bytes.NewReader(index), &multiMapBlobStore{blobs: blobs}, &out)
+	if err == nil {
+		t.Fatal("reconstruction succeeded with a blob missing from the store")
+	}
+	if !strings.Contains(err.Error(), "blob not found") {
+		t.Fatalf("error = %v, want it to name the missing blob", err)
+	}
+}
+
+type countingCloser struct {
+	io.Reader
+	closed *int
+}
+
+func (c *countingCloser) Close() error {
+	*c.closed++
+	return nil
+}

--- a/img_tool/pkg/compactstream/reader.go
+++ b/img_tool/pkg/compactstream/reader.go
@@ -329,7 +329,17 @@ func (zeroReader) Read(p []byte) (int, error) {
 // by interleaving the on-disk byte-stream gaps with the CAS-referenced blobs in
 // offset order. It streams the result: memory use is O(copy buffer), so it never
 // materializes the whole tar.
+//
+// The blobs arrive as one stream over the whole reference table rather than one
+// reader per reference, so a store that can fetch several blobs per request (a
+// [MultiBlobStore]) gets to see the whole list and batch it.
 func writeReconstructed(ctx context.Context, dst io.Writer, stream io.Reader, refs []CASReference, store BlobStore) error {
+	blobs, err := blobStreamFor(ctx, store, blobRequests(refs))
+	if err != nil {
+		return fmt.Errorf("opening CAS blob stream: %w", err)
+	}
+	defer blobs.Close()
+
 	var outputPos uint64
 	for _, r := range refs {
 		// readRefTable already rejects unsorted/overlapping refs; this guard is
@@ -343,16 +353,9 @@ func writeReconstructed(ctx context.Context, dst io.Writer, stream io.Reader, re
 				return fmt.Errorf("copying stream bytes at offset %d (gap %d): %w", outputPos, gap, err)
 			}
 		}
-
-		blobReader, err := store.ReaderForBlob(ctx, r.Digest, int64(r.Size))
-		if err != nil {
-			return fmt.Errorf("fetching blob at offset %d: %w", r.Offset, err)
-		}
-		if _, err := io.CopyN(dst, blobReader, int64(r.Size)); err != nil {
-			blobReader.Close()
+		if _, err := io.CopyN(dst, blobs, int64(r.Size)); err != nil {
 			return fmt.Errorf("reading blob at offset %d: %w", r.Offset, err)
 		}
-		blobReader.Close()
 
 		outputPos = r.Offset + r.Size
 	}
@@ -361,6 +364,15 @@ func writeReconstructed(ctx context.Context, dst io.Writer, stream io.Reader, re
 		return fmt.Errorf("copying remaining stream bytes: %w", err)
 	}
 	return nil
+}
+
+// blobRequests is the blob list of a reference table, in stream order.
+func blobRequests(refs []CASReference) []BlobRequest {
+	requests := make([]BlobRequest, len(refs))
+	for i, r := range refs {
+		requests[i] = BlobRequest{Digest: r.Digest, Size: int64(r.Size)}
+	}
+	return requests
 }
 
 // hashCountWriter forwards writes to an underlying writer while computing a

--- a/img_tool/pkg/deployvfs/BUILD.bazel
+++ b/img_tool/pkg/deployvfs/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
 go_test(
     name = "deployvfs_test",
     srcs = [
+        "compactstream_multiblob_test.go",
         "compactstream_test.go",
         "crossmount_test.go",
         "layersource_test.go",

--- a/img_tool/pkg/deployvfs/compactstream.go
+++ b/img_tool/pkg/deployvfs/compactstream.go
@@ -274,3 +274,96 @@ func (s *casDirStore) ReaderForBlob(ctx context.Context, digest []byte, size int
 
 	return nil, fmt.Errorf("blob sha256:%s (size %d) not found in input file CAS directory, disk cache, or remote cache", hexDigest, size)
 }
+
+var _ compactstream.MultiBlobStore = (*casDirStore)(nil)
+
+// ReaderForBlobs serves a whole list of CAS references as one stream. Blobs the
+// store has locally are read one file at a time as before; every run of blobs
+// only the remote cache can serve is handed to it in one piece, so it reads them
+// in batches instead of paying a round trip per blob. A compact stream for a
+// layer of many small files is thousands of such references, which is where the
+// difference is felt.
+func (s *casDirStore) ReaderForBlobs(ctx context.Context, requests []compactstream.BlobRequest) (io.ReadCloser, error) {
+	parts := make([]compactstream.BlobStreamPart, 0, len(requests))
+	for _, run := range s.planRuns(requests) {
+		runRequests := requests[run.from:run.to]
+		if !run.remote {
+			for _, request := range runRequests {
+				parts = append(parts, compactstream.BlobStreamPart{
+					Size: request.Size,
+					Open: func() (io.ReadCloser, error) {
+						return s.ReaderForBlob(ctx, request.Digest, request.Size)
+					},
+				})
+			}
+			continue
+		}
+		digests := make([]cas.Digest, len(runRequests))
+		var total int64
+		for i, request := range runRequests {
+			digests[i] = cas.SHA256(request.Digest, request.Size)
+			total += request.Size
+		}
+		parts = append(parts, compactstream.BlobStreamPart{
+			Size: total,
+			Open: func() (io.ReadCloser, error) {
+				return s.casReader.ReaderForBlobs(ctx, digests)
+			},
+		})
+	}
+	return compactstream.NewBlobStream(parts), nil
+}
+
+// blobRun is a run of consecutive requests one source serves.
+type blobRun struct {
+	from, to int
+	remote   bool
+}
+
+// planRuns splits the requests into runs served locally (from the input
+// directory or the disk cache) and runs the remote cache has to serve.
+//
+// Deciding needs a stat per blob, which is cheap next to the round trip it
+// saves, and only the genuinely mixed configuration pays for it: a store with no
+// local directory is one remote run, and a store with no remote cache is one
+// local run. A stale answer costs a misplaced run boundary at worst -- a local
+// blob is read back through ReaderForBlob, which falls through to the remote
+// cache if the file went away in the meantime.
+func (s *casDirStore) planRuns(requests []compactstream.BlobRequest) []blobRun {
+	if len(requests) == 0 {
+		return nil
+	}
+	if s.casReader == nil {
+		return []blobRun{{from: 0, to: len(requests)}}
+	}
+	if s.shaDir == "" && s.diskCachePath == "" {
+		return []blobRun{{from: 0, to: len(requests), remote: true}}
+	}
+	var runs []blobRun
+	for i, request := range requests {
+		remote := !s.hasLocally(request.Digest, request.Size)
+		if n := len(runs); n > 0 && runs[n-1].remote == remote {
+			runs[n-1].to = i + 1
+			continue
+		}
+		runs = append(runs, blobRun{from: i, to: i + 1, remote: remote})
+	}
+	return runs
+}
+
+// hasLocally reports whether the blob can be served without the remote cache. It
+// mirrors the first two steps of ReaderForBlob.
+func (s *casDirStore) hasLocally(digest []byte, size int64) bool {
+	hexDigest := hex.EncodeToString(digest)
+	if s.shaDir != "" {
+		if _, err := os.Stat(filepath.Join(s.shaDir, hexDigest)); err == nil {
+			return true
+		}
+	}
+	if s.diskCachePath != "" {
+		if info, err := os.Stat(diskCacheBlobPath(s.diskCachePath, "sha256:"+hexDigest)); err == nil && info.Size() == size {
+			return true
+		}
+	}
+	return false
+}

--- a/img_tool/pkg/deployvfs/compactstream_multiblob_test.go
+++ b/img_tool/pkg/deployvfs/compactstream_multiblob_test.go
@@ -1,0 +1,203 @@
+package deployvfs
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/compactstream"
+)
+
+// recordingCASReader is a stubCASReader that records the digest lists its
+// ReaderForBlobs was handed, so a test can tell how a request was grouped.
+type recordingCASReader struct {
+	stubCASReader
+	lists [][]string // hex hashes per ReaderForBlobs call
+}
+
+func (s *recordingCASReader) ReaderForBlobs(ctx context.Context, digests []cas.Digest) (io.ReadCloser, error) {
+	hashes := make([]string, len(digests))
+	for i, d := range digests {
+		hashes[i] = hex.EncodeToString(d.Hash)
+	}
+	s.lists = append(s.lists, hashes)
+	return s.stubCASReader.ReaderForBlobs(ctx, digests)
+}
+
+// blobSet is a set of test blobs addressed by content.
+type blobSet struct {
+	contents [][]byte
+	requests []compactstream.BlobRequest
+	byHash   map[string][]byte
+}
+
+func makeBlobs(n int) blobSet {
+	set := blobSet{byHash: map[string][]byte{}}
+	for i := range n {
+		content := []byte(fmt.Sprintf("blob-%02d-content", i))
+		digest := sha256.Sum256(content)
+		set.contents = append(set.contents, content)
+		set.requests = append(set.requests, compactstream.BlobRequest{Digest: digest[:], Size: int64(len(content))})
+		set.byHash[hex.EncodeToString(digest[:])] = content
+	}
+	return set
+}
+
+func (b blobSet) joined(indices ...int) []byte {
+	var out []byte
+	for _, i := range indices {
+		out = append(out, b.contents[i]...)
+	}
+	return out
+}
+
+func (b blobSet) all() []byte {
+	return b.joined(rangeN(len(b.contents))...)
+}
+
+func rangeN(n int) []int {
+	out := make([]int, n)
+	for i := range out {
+		out[i] = i
+	}
+	return out
+}
+
+func readBlobStream(t *testing.T, s *casDirStore, requests []compactstream.BlobRequest) []byte {
+	t.Helper()
+	rc, err := s.ReaderForBlobs(context.Background(), requests)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return readAllClose(t, rc)
+}
+
+// With nothing local, the whole reference table goes to the remote cache in one
+// piece -- which is what lets it batch.
+func TestCasDirStoreReadsAllRemoteBlobsAsOneRun(t *testing.T) {
+	blobs := makeBlobs(6)
+	remote := &recordingCASReader{stubCASReader: stubCASReader{blobs: blobs.byHash}}
+	s := &casDirStore{casReader: remote}
+
+	if got := readBlobStream(t, s, blobs.requests); !bytes.Equal(got, blobs.all()) {
+		t.Fatalf("stream = %q, want %q", got, blobs.all())
+	}
+	if len(remote.lists) != 1 {
+		t.Fatalf("remote cache saw %d lists, want 1", len(remote.lists))
+	}
+	if len(remote.lists[0]) != len(blobs.requests) {
+		t.Fatalf("remote cache was asked for %d blobs, want %d", len(remote.lists[0]), len(blobs.requests))
+	}
+}
+
+// Blobs shipped in the input directory are read from disk, and the remote cache
+// is never called.
+func TestCasDirStoreReadsAllLocalBlobsWithoutTheRemoteCache(t *testing.T) {
+	blobs := makeBlobs(4)
+	shaDir := filepath.Join(t.TempDir(), "sha256")
+	for hash, content := range blobs.byHash {
+		writeBlobFile(t, filepath.Join(shaDir, hash), content)
+	}
+	remote := &recordingCASReader{stubCASReader: stubCASReader{blobs: map[string][]byte{}}}
+	s := &casDirStore{shaDir: shaDir, casReader: remote}
+
+	if got := readBlobStream(t, s, blobs.requests); !bytes.Equal(got, blobs.all()) {
+		t.Fatalf("stream = %q, want %q", got, blobs.all())
+	}
+	if len(remote.lists) != 0 {
+		t.Fatalf("remote cache was called %d times for blobs the input directory has", len(remote.lists))
+	}
+}
+
+// A mixed store groups the remote blobs into runs instead of fetching them one
+// by one, and still serves the local ones from disk.
+func TestCasDirStoreGroupsRemoteRunsAroundLocalBlobs(t *testing.T) {
+	blobs := makeBlobs(7)
+	// Ship blobs 2 and 5 locally; 0-1, 3-4 and 6 must come from the remote cache.
+	shaDir := filepath.Join(t.TempDir(), "sha256")
+	local := []int{2, 5}
+	remoteBlobs := map[string][]byte{}
+	for i, request := range blobs.requests {
+		hash := hex.EncodeToString(request.Digest)
+		if slices.Contains(local, i) {
+			writeBlobFile(t, filepath.Join(shaDir, hash), blobs.contents[i])
+			continue
+		}
+		remoteBlobs[hash] = blobs.contents[i]
+	}
+	remote := &recordingCASReader{stubCASReader: stubCASReader{blobs: remoteBlobs}}
+	s := &casDirStore{shaDir: shaDir, casReader: remote}
+
+	if got := readBlobStream(t, s, blobs.requests); !bytes.Equal(got, blobs.all()) {
+		t.Fatalf("stream = %q, want %q", got, blobs.all())
+	}
+	var gotRuns [][]string
+	for _, list := range remote.lists {
+		gotRuns = append(gotRuns, list)
+	}
+	wantRuns := [][]string{
+		{hexOf(blobs, 0), hexOf(blobs, 1)},
+		{hexOf(blobs, 3), hexOf(blobs, 4)},
+		{hexOf(blobs, 6)},
+	}
+	if fmt.Sprint(gotRuns) != fmt.Sprint(wantRuns) {
+		t.Fatalf("remote runs = %v, want %v", gotRuns, wantRuns)
+	}
+}
+
+// A blob the disk cache has is local too, as long as its size matches.
+func TestCasDirStoreTreatsDiskCacheHitsAsLocal(t *testing.T) {
+	blobs := makeBlobs(2)
+	diskCache := t.TempDir()
+	writeBlobFile(t, diskCacheBlobPath(diskCache, "sha256:"+hexOf(blobs, 0)), blobs.contents[0])
+	remote := &recordingCASReader{stubCASReader: stubCASReader{blobs: map[string][]byte{
+		hexOf(blobs, 1): blobs.contents[1],
+	}}}
+	s := &casDirStore{diskCachePath: diskCache, casReader: remote}
+
+	if got := readBlobStream(t, s, blobs.requests); !bytes.Equal(got, blobs.all()) {
+		t.Fatalf("stream = %q, want %q", got, blobs.all())
+	}
+	if len(remote.lists) != 1 || len(remote.lists[0]) != 1 {
+		t.Fatalf("remote cache saw %v, want only the uncached blob", remote.lists)
+	}
+}
+
+// Without a remote cache the store still serves the list; a blob it does not
+// have fails with the usual not-found error rather than a nil dereference.
+func TestCasDirStoreReadsBlobsWithoutARemoteCache(t *testing.T) {
+	blobs := makeBlobs(2)
+	shaDir := filepath.Join(t.TempDir(), "sha256")
+	writeBlobFile(t, filepath.Join(shaDir, hexOf(blobs, 0)), blobs.contents[0])
+	s := &casDirStore{shaDir: shaDir}
+
+	rc, err := s.ReaderForBlobs(context.Background(), blobs.requests)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	if _, err := io.ReadAll(rc); err == nil || !strings.Contains(err.Error(), "not found in input file CAS directory") {
+		t.Fatalf("error = %v, want the not-found error for the second blob", err)
+	}
+}
+
+// The store is what Reconstruct looks for; a compact stream must go through the
+// batched path.
+func TestCasDirStoreIsAMultiBlobStore(t *testing.T) {
+	var store compactstream.BlobStore = &casDirStore{}
+	if _, ok := store.(compactstream.MultiBlobStore); !ok {
+		t.Fatal("casDirStore does not implement compactstream.MultiBlobStore")
+	}
+}
+
+func hexOf(blobs blobSet, i int) string {
+	return hex.EncodeToString(blobs.requests[i].Digest)
+}

--- a/img_tool/pkg/deployvfs/compactstream_test.go
+++ b/img_tool/pkg/deployvfs/compactstream_test.go
@@ -42,6 +42,18 @@ func (s *stubCASReader) ReaderForBlob(_ context.Context, d cas.Digest) (io.ReadC
 	return io.NopCloser(bytes.NewReader(b)), nil
 }
 
+func (s *stubCASReader) ReaderForBlobs(ctx context.Context, digests []cas.Digest) (io.ReadCloser, error) {
+	var buf bytes.Buffer
+	for _, d := range digests {
+		b, err := s.ReadBlob(ctx, d)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(b)
+	}
+	return io.NopCloser(&buf), nil
+}
+
 func writeBlobFile(t *testing.T, path string, data []byte) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -1215,6 +1215,7 @@ type casReader interface {
 	FindMissingBlobs(ctx context.Context, digests []cas.Digest) ([]cas.Digest, error)
 	ReadBlob(ctx context.Context, digest cas.Digest) ([]byte, error)
 	ReaderForBlob(ctx context.Context, digest cas.Digest) (io.ReadCloser, error)
+	ReaderForBlobs(ctx context.Context, digests []cas.Digest) (io.ReadCloser, error)
 }
 
 func digestFromDescriptor(blobMeta api.Descriptor) (cas.Digest, error) {

--- a/img_tool/pkg/serve/bes/syncer/syncer.go
+++ b/img_tool/pkg/serve/bes/syncer/syncer.go
@@ -1214,8 +1214,20 @@ type casBlobStore struct {
 	syncer *Syncer
 }
 
+var _ compactstream.MultiBlobStore = (*casBlobStore)(nil)
+
 func (s *casBlobStore) ReaderForBlob(ctx context.Context, digest []byte, size int64) (io.ReadCloser, error) {
 	return s.syncer.casClient.ReaderForBlob(ctx, cas.SHA256(digest, size))
+}
+
+// ReaderForBlobs hands the whole reference table to the CAS client so it reads
+// the small blobs in batches instead of one round trip each.
+func (s *casBlobStore) ReaderForBlobs(ctx context.Context, requests []compactstream.BlobRequest) (io.ReadCloser, error) {
+	digests := make([]cas.Digest, len(requests))
+	for i, request := range requests {
+		digests[i] = cas.SHA256(request.Digest, request.Size)
+	}
+	return s.syncer.casClient.ReaderForBlobs(ctx, digests)
 }
 
 // casDigestFromString parses a "sha256:<hex>" digest string with the given size


### PR DESCRIPTION
To reconstruct a compact layer, `img` reads each file that the layer
index refers to from the remote cache. Before this change, it read the
files one at a time. It opened a reader for a blob, copied the bytes,
closed the reader, and started the next blob.

A layer with many small files paid one round trip for each file. One
example layer has almost 7000 references. The average reference is about
38 KiB. At a round trip time of 23 ms, this is more than two minutes of
delay. The layer came in at 1-2 MiB/s. One large read on the same route
was more than 60 MiB/s.

The new code does not ask for the blobs one at a time. The blob store
gets the full reference table first, as a list. The store gives back one
stream that contains all the blobs in the same sequence. The caller
cannot see a difference from the sequence of readers that it got before.
The store selects how to get the data.

## The interface

`compactstream.MultiBlobStore` is an optional extension of `BlobStore`:

	ReaderForBlobs(ctx, []BlobRequest) (io.ReadCloser, error)

`BlobStreamPart` and `NewBlobStream` are the parts below it. Together
they make a reader for a list of parts. Each part has a known length,
and the reader opens a part only when it gets to that part. A part is
one blob, or a group of blobs from the same source. A plain `BlobStore`
uses the same code with one part for each blob, as before.

`writeReconstructed` is now shorter than before. It puts the gaps from
the byte stream and the blobs from the blob stream together, and it does
no more than that. It does not open and close a reader for each
reference, and it has no special path for a large blob.

## The batches

`cas.BlobSource` gets the same function, and `*CAS` makes the batch
real. The package had no read for more than one blob: `batchReadOne`
sent a `BatchReadBlobs` request with exactly one digest. The new code
puts as many small digests in one request as `MaxBatchTotalSizeBytes`
allows. For the example layer, this changes 7000 round trips to about
110. A blob that is too large for a batch continues to use ByteStream,
one blob at a time.

Each blob also pays for its own frame bytes, and not only for its data.
`batchPayloadBudget` keeps 1 KiB back for the frame, but that value is
correct only for a request with one blob. The frame of a batch increases
with the number of blobs in it, and one thousand blobs need eighty times
that value. If a blob does not fit when you add the frame, the code
streams the blob. This rule also prevents an empty batch.

The code gets a batch only when the consumer needs it. The memory thus
stays at one batch, and the length of the list makes no difference. If a
list refers to the same blob two times, the code asks for the blob one
time and gives the bytes two times.

The code matches each response to its request by digest, and not by
position. The specification does not promise a sequence. Also, a request
with fewer digests has fewer responses than places to fill.
`batchReadOne` now calls the same function with a list of one digest, so
there is one implementation and not two.

`Pool` gives the full list to one member, so the batches of one stream
stay on one connection. Different streams still go to different members.

`CachingReader` gives the blobs that it has on the disk. It also gives
the blobs that another reader gets at the same time, from that reader.
It batches only the blobs between them. It writes what it gets into the
cache, and a later deploy finds the blobs there. If a blob is too large
for the memory, the single-blob path streams it into the cache.

## The deploy

`casDirStore` finds a reference in the input directory of the layer, in
the disk cache, or in the remote cache, in that sequence. It now divides
the list into groups. It reads a local blob from a file, as before. It
gives each group that only the remote cache has to that cache in one
piece.

To divide the list, `casDirStore` does one `stat` for each blob. A
`stat` is much faster than a round trip. Only a store that has both a
local directory and a remote cache does this work. The eager strategies
and the lazy strategies each make one group. The compact stream store of
the BES syncer batches in the same way.
