### PR TITLE
docs(registry-support): qualify ECR blob mount with manifest-reference requirement

### DIFF
--- a/docs/registry-support.md
+++ b/docs/registry-support.md
@@ -55,9 +55,9 @@ manifest referencing it has been created).
 
 | Registry | OCI 1.1 referrers | Blob mount | Anonymous mount | Cross-registry mount | Automatic cross-repository sharing |
 | --- | --- | --- | --- | --- | --- |
-| Amazon ECR | ✅ [[1]](https://aws.amazon.com/blogs/opensource/diving-into-oci-image-and-distribution-1-1-support-in-amazon-ecr/) | ✅ [[2]](https://docs.aws.amazon.com/AmazonECR/latest/userguide/blob-mounting.html) | ❓ | ❓ | ❌ |
-| Docker Hub | ❓ | ✅ [[3]](https://docs.docker.com/reference/api/registry/latest/) | ❓ | ❌ | ❌ |
-| Google Artifact Registry | ✅ [[4]](https://docs.cloud.google.com/artifact-registry/docs/manage-metadata-with-attachments) | ✅ | ❓ | ✅ [[5]](https://github.com/google/go-containerregistry/issues/1321) | ❌ |
+| Amazon ECR | ✅ [[1]](https://aws.amazon.com/blogs/opensource/diving-into-oci-image-and-distribution-1-1-support-in-amazon-ecr/) | ✅ after a manifest references the blob [[2]](https://docs.aws.amazon.com/AmazonECR/latest/userguide/blob-mounting.html) [[3]](https://github.com/aws/containers-roadmap/issues/2860) | ❓ | ❓ | ❌ |
+| Docker Hub | ❓ | ✅ [[4]](https://docs.docker.com/reference/api/registry/latest/) | ❓ | ❌ | ❌ |
+| Google Artifact Registry | ✅ [[5]](https://docs.cloud.google.com/artifact-registry/docs/manage-metadata-with-attachments) | ✅ | ❓ | ✅ [[6]](https://github.com/google/go-containerregistry/issues/1321) | ❌ |
 | Harbor | ✅ | ✅ | ❌ | ❓ | ❌ |
 | JFrog Artifactory | ✅ | ❌ | ❌ | ❌ | ✅ after a manifest references the blob |
 


### PR DESCRIPTION
ECR only makes a blob mountable after a manifest referencing it has been created. Add that qualifier to the matrix entry and link to the open containers-roadmap issue tracking the behaviour.

Renumber footnotes 3–5 → 4–6 to make room for the new reference [3].