### PR TITLE
feat(gateway): report the stage of a network error in error.type

### DIFF
--- a/img_tool/cmd/oci-distribution-gateway/README.md
+++ b/img_tool/cmd/oci-distribution-gateway/README.md
@@ -871,9 +871,38 @@ either: one message carries facts about several.
 
 `error.type` is a fixed set, grouped by who is at fault:
 
-- **network** — `connection_refused`, `connection_reset`, `network_unreachable`,
-  `timeout`, `dns`, `tls`, `tls_certificate`, `network`, `transfer_aborted`,
-  `client_canceled`
+- **network** — split by the stage of the connection that failed, because "the
+  registry was unreachable" is not something you can act on while "the name did
+  not resolve" or "the peer rejected our certificate" is. Each stage keeps a
+  generic member for causes that cannot be placed more precisely:
+  - *resolving the name* — `dns_not_found` (NXDOMAIN: a typo, or a resolver that
+    does not serve that zone), `dns_timeout` (the resolver did not answer; the
+    registry may be fine), `dns`
+  - *reaching the endpoint* — `connection_refused` (the host is up, nothing is
+    listening), `host_unreachable`, `network_unreachable` (no route: this
+    gateway's own networking), `dial_timeout` (packets dropped silently, which
+    is what a firewall looks like), `proxy_connect` (the *proxy* could not be
+    reached — a different address to debug), `local_resource_exhausted` (this
+    process ran out of sockets or file descriptors; raise the limit or find the
+    leak)
+  - *establishing TLS* — `tls_certificate_untrusted` (missing CA bundle or an
+    intercepting proxy), `tls_certificate_expired`, `tls_certificate_hostname`,
+    `tls_certificate`, `tls_client_certificate_rejected` (the far end rejected
+    *ours* — on the forwarding hop, the mTLS peer credential),
+    `tls_plaintext` (the endpoint answered with something that is not TLS,
+    usually a plain HTTP service on an HTTPS port), `tls_handshake_timeout`,
+    `tls`
+  - *on an established connection* — `connection_reset`, `broken_pipe` (we wrote
+    to a connection the other end had closed: on the response path, a client
+    that hung up), `unexpected_eof` (the body stopped short of its
+    Content-Length, so the content is truncated, not merely late),
+    `read_timeout` (the other end stopped sending), `write_timeout` (the other
+    end stopped reading), `http2_goaway` (the peer took the connection away —
+    expected during a rolling restart and under a mesh's max connection age),
+    `http2_stream` (a stream-level error, including `REFUSED_STREAM` from the
+    concurrent-stream limit), `timeout`, `network`
+  - *neither end's fault* — `transfer_aborted` (the copy failed and neither half
+    can be blamed), `client_canceled`
 - **upstream auth** — `upstream_auth` (credential resolution, ping, or token
   exchange), `upstream_unauthorized` (401)
 - **permission denied** — `policy_denied`, `registry_denied`, `mount_denied`
@@ -947,6 +976,17 @@ sum(rate(oci_gateway_blob_existence_cache_replication_dropped_total[5m]))
 # Errors per second by type and registry.
 sum by (error_type, oci_registry) (rate(oci_gateway_errors_total[5m]))
 
+# Which *stage* of the connection is failing? Resolution, reaching the endpoint,
+# TLS, and an established connection are four different on-call responses.
+sum by (error_type) (rate(oci_gateway_errors_total{error_type=~"dns.*"}[5m]))
+sum by (error_type) (rate(oci_gateway_errors_total{error_type=~"connection_refused|.*_unreachable|dial_timeout|proxy_connect"}[5m]))
+sum by (error_type) (rate(oci_gateway_errors_total{error_type=~"tls.*"}[5m]))
+
+# Two of those need no dashboard reading at all — they are always a
+# misconfiguration, never load: this gateway is out of sockets, or the endpoint
+# on the other side is not speaking TLS. Alert on them.
+sum(rate(oci_gateway_errors_total{error_type=~"local_resource_exhausted|tls_plaintext|tls_certificate_expired"}[15m]))
+
 # Requests denied by policy.
 sum by (oci_registry, oci_operation) (rate(oci_gateway_policy_decisions_total{oci_policy_decision="deny"}[5m]))
 
@@ -1005,8 +1045,13 @@ histogram_quantile(0.95, sum by (le) (rate(oci_gateway_forward_peer_duration_sec
 sum by (network_protocol_version) (rate(oci_gateway_forward_peer_duration_seconds_count[5m]))
 
 # 3. Is the hop failing, and whose fault is it?
-#    peer_unauthorized / peer_forbidden mean OUR peer credential is wrong.
-#    connection_refused / tls_certificate mean we cannot reach or trust the peer.
+#    peer_unauthorized / peer_forbidden mean OUR peer credential is wrong, and so
+#    does tls_client_certificate_rejected — the peer refused our certificate
+#    before any HTTP was exchanged.
+#    connection_refused / dial_timeout / tls_certificate_* mean we cannot reach
+#    or trust the peer.
+#    http2_goaway is the peer taking the pinned connection away: a rolling
+#    restart, or a service mesh's max connection age.
 sum by (error_type) (rate(oci_gateway_forward_errors_total[5m]))
 ```
 

--- a/img_tool/pkg/serve/gateway/errclass.go
+++ b/img_tool/pkg/serve/gateway/errclass.go
@@ -5,8 +5,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"io"
 	"net"
 	"net/http"
+	"strings"
 	"syscall"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -17,6 +19,13 @@ import (
 // are a fixed, low-cardinality set — never a Go error string — and are grouped
 // so that an operator can answer "is this us, the client, the network, or the
 // upstream registry?" without reading logs.
+//
+// Within the network group the value also names the stage of the connection
+// that failed — resolution, reaching the endpoint, TLS, or an established
+// connection. That is the difference between a metric that says a request
+// failed and one that says where to look: a name that does not resolve, a
+// connect that times out, a rejected client certificate and a body that stops
+// half way are four unrelated problems with four unrelated fixes.
 
 // Error types the gateway reports for requests it rejects itself, before any
 // upstream connection is made.
@@ -95,21 +104,104 @@ const (
 	errBadUpstreamRequest = "bad_upstream_request"
 )
 
-// Error types for the network and the client connection.
+// Error types for the network, grouped by the stage of the connection that
+// failed. The stage is the point of the split: "the gateway could not talk to
+// the registry" is not an actionable statement, while "the name did not
+// resolve", "the TCP connect timed out", "the peer rejected our client
+// certificate" and "the upstream closed the body half way" each send an
+// operator to a different place. Every group keeps a generic member as the
+// fallback for causes the classifier cannot place more precisely.
 const (
-	errConnectionRefused  = "connection_refused"
-	errConnectionReset    = "connection_reset"
+	// Resolving the name.
+	//
+	// errDNSNotFound: NXDOMAIN. The host does not exist — a typo in the
+	// registry name, or a split-horizon resolver that does not serve it.
+	errDNSNotFound = "dns_not_found"
+	// errDNSTimeout: the resolver did not answer. The registry may be fine.
+	errDNSTimeout = "dns_timeout"
+	// errDNS: any other resolution failure (SERVFAIL, no usable records).
+	errDNS = "dns"
+
+	// Reaching the endpoint.
+	//
+	// errConnectionRefused: something answered the port with a RST. The host is
+	// up and nothing is listening, so this is a wrong port or a dead upstream.
+	errConnectionRefused = "connection_refused"
+	// errHostUnreachable: the network is up but that host is not (EHOSTUNREACH).
+	errHostUnreachable = "host_unreachable"
+	// errNetworkUnreachable: no route at all (ENETUNREACH, ENETDOWN) — this
+	// gateway's own networking, not the upstream's.
 	errNetworkUnreachable = "network_unreachable"
-	errTimeout            = "timeout"
-	errDNS                = "dns"
-	errTLS                = "tls"
-	errTLSCertificate     = "tls_certificate"
-	errNetwork            = "network"
-	errRedirectRefused    = "redirect_refused"
-	errTooManyRedirects   = "too_many_redirects"
-	errClientCanceled     = "client_canceled"
-	errTransferAborted    = "transfer_aborted"
-	errTypeUnknown        = "unknown"
+	// errDialTimeout: the TCP connect never completed. Packets are being dropped
+	// silently, which is what a firewall or a black-holed address looks like.
+	errDialTimeout = "dial_timeout"
+	// errProxyConnect: the failure was reaching the HTTP proxy, not the registry.
+	// Kept separate because the address to debug is a different one.
+	errProxyConnect = "proxy_connect"
+	// errLocalResourceExhausted: this process ran out of sockets or file
+	// descriptors (EADDRNOTAVAIL, EADDRINUSE, EMFILE, ENFILE). Nothing is wrong
+	// with the network: raise the limit, or find the connection leak.
+	errLocalResourceExhausted = "local_resource_exhausted"
+
+	// Establishing TLS.
+	//
+	// errTLSCertificateUntrusted: the chain does not lead to a trusted root — a
+	// missing CA bundle or an intercepting proxy.
+	errTLSCertificateUntrusted = "tls_certificate_untrusted"
+	// errTLSCertificateExpired: the upstream's certificate is out of date.
+	errTLSCertificateExpired = "tls_certificate_expired"
+	// errTLSCertificateHostname: a valid certificate for a different name.
+	errTLSCertificateHostname = "tls_certificate_hostname"
+	// errTLSCertificate: any other verification failure.
+	errTLSCertificate = "tls_certificate"
+	// errTLSClientCertRejected: the other end rejected *our* certificate. On the
+	// gateway-to-gateway hop this is the mTLS credential, and it is the failure
+	// most easily mistaken for a generic network problem.
+	errTLSClientCertRejected = "tls_client_certificate_rejected"
+	// errTLSPlaintext: the endpoint answered a TLS handshake with something that
+	// is not TLS — usually a plain HTTP service on an HTTPS port.
+	errTLSPlaintext = "tls_plaintext"
+	// errTLSHandshakeTimeout: connected, but the handshake never finished.
+	errTLSHandshakeTimeout = "tls_handshake_timeout"
+	// errTLS: any other handshake failure (version or cipher mismatch, alerts
+	// that are not about a certificate).
+	errTLS = "tls"
+
+	// On an established connection.
+	//
+	// errConnectionReset: the other end sent a RST (ECONNRESET, ECONNABORTED).
+	errConnectionReset = "connection_reset"
+	// errBrokenPipe: we wrote to a connection the other end had already closed
+	// (EPIPE). On the response path that is a client that hung up, not an
+	// upstream fault, which is why it is not lumped in with a reset.
+	errBrokenPipe = "broken_pipe"
+	// errUnexpectedEOF: the body ended early. The bytes on the wire disagree with
+	// the Content-Length, so the content is truncated, not merely late.
+	errUnexpectedEOF = "unexpected_eof"
+	// errReadTimeout: the other end stopped sending mid-transfer.
+	errReadTimeout = "read_timeout"
+	// errWriteTimeout: the other end stopped reading — backpressure, typically a
+	// slow client or an upstream that stalled on an upload.
+	errWriteTimeout = "write_timeout"
+	// errHTTP2GoAway: the peer asked us to stop using the connection. Expected
+	// during a rolling restart, and expected forever under a service mesh with a
+	// max connection age; a steady rate outside those is worth chasing.
+	errHTTP2GoAway = "http2_goaway"
+	// errHTTP2Stream: a stream-level HTTP/2 error, including REFUSED_STREAM from
+	// exceeding the peer's concurrent-stream limit.
+	errHTTP2Stream = "http2_stream"
+	// errTimeout: a timeout that cannot be attributed to a stage, such as an
+	// overall request deadline.
+	errTimeout = "timeout"
+	// errNetwork: any other network failure.
+	errNetwork = "network"
+
+	// Not the network: the gateway's own redirect policy and the client.
+	errRedirectRefused  = "redirect_refused"
+	errTooManyRedirects = "too_many_redirects"
+	errClientCanceled   = "client_canceled"
+	errTransferAborted  = "transfer_aborted"
+	errTypeUnknown      = "unknown"
 )
 
 // Sentinels for the redirect policy, so a refused redirect can be classified
@@ -126,6 +218,10 @@ var (
 // into one of the fixed error.type values. Errors are unwrapped, so the
 // [url.Error] and [transport.Error] wrappers net/http and
 // go-containerregistry add do not hide the cause.
+//
+// The order of the checks is the order of the connection: a cause found early
+// is the one that actually failed, and a later, vaguer match (every network
+// error is ultimately a [net.OpError]) would only bury it.
 func transportErrorType(err error) string {
 	if err == nil {
 		return ""
@@ -150,58 +246,164 @@ func transportErrorType(err error) string {
 		return errUpstreamClientError
 	}
 
-	switch {
-	case errors.Is(err, context.Canceled):
-		// The request context is canceled when the client goes away (or when the
-		// gateway shuts down), not by anything upstream.
+	// The request context is canceled when the client goes away (or when the
+	// gateway shuts down), not by anything upstream.
+	if errors.Is(err, context.Canceled) {
 		return errClientCanceled
-	case errors.Is(err, context.DeadlineExceeded):
-		return errTimeout
-	case errors.Is(err, syscall.ECONNREFUSED):
-		return errConnectionRefused
-	case errors.Is(err, syscall.ECONNRESET), errors.Is(err, syscall.EPIPE):
-		return errConnectionReset
-	case errors.Is(err, syscall.EHOSTUNREACH), errors.Is(err, syscall.ENETUNREACH), errors.Is(err, syscall.ENETDOWN):
-		return errNetworkUnreachable
 	}
 
+	// Name resolution, before anything reaches the wire.
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
+		switch {
+		case dnsErr.IsNotFound:
+			return errDNSNotFound
+		case dnsErr.IsTimeout:
+			return errDNSTimeout
+		}
 		return errDNS
 	}
 
-	// TLS trust problems are their own class: they are almost always a
-	// misconfigured CA bundle or an intercepting proxy, not a flaky network.
-	var certErr *tls.CertificateVerificationError
-	var authorityErr x509.UnknownAuthorityError
-	var hostnameErr x509.HostnameError
-	var certInvalidErr x509.CertificateInvalidError
-	switch {
-	case errors.As(err, &certErr), errors.As(err, &authorityErr),
-		errors.As(err, &hostnameErr), errors.As(err, &certInvalidErr):
-		return errTLSCertificate
-	}
-	var recordErr tls.RecordHeaderError
-	var alertErr tls.AlertError
-	switch {
-	case errors.As(err, &recordErr), errors.As(err, &alertErr):
-		return errTLS
+	// net.OpError carries the stage that failed in its Op ("dial", "read",
+	// "write", "proxyconnect", "remote error"), which is what makes a timeout or
+	// a TLS alert attributable to a stage rather than to "the network". It stays
+	// nil when there is none: errors.As only assigns on a match.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Op == "proxyconnect" {
+		return errProxyConnect
 	}
 
-	// net.Error covers timeouts that are not context deadlines (dial and TLS
-	// handshake deadlines, for example).
-	var netErr net.Error
-	if errors.As(err, &netErr) {
-		if netErr.Timeout() {
-			return errTimeout
-		}
-		return errNetwork
+	if t := tlsErrorType(err, opErr); t != "" {
+		return t
 	}
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
+	if t := syscallErrorType(err); t != "" {
+		return t
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return errUnexpectedEOF
+	}
+	if t := http2ErrorType(err); t != "" {
+		return t
+	}
+
+	// Timeouts, attributed to the stage that timed out. net.Error covers the
+	// ones that are not context deadlines (dial and I/O deadlines).
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		if opErr != nil {
+			switch opErr.Op {
+			case "dial":
+				return errDialTimeout
+			case "read":
+				return errReadTimeout
+			case "write":
+				return errWriteTimeout
+			}
+		}
+		return errTimeout
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return errTimeout
+	}
+
+	if netErr != nil || opErr != nil {
 		return errNetwork
 	}
 	return errTypeUnknown
+}
+
+// tlsErrorType classifies a failure to establish or hold up TLS, or returns the
+// empty string when the error is not a TLS one.
+func tlsErrorType(err error, opErr *net.OpError) string {
+	// Verifying the *other* end's certificate. The specific reasons come first:
+	// tls.CertificateVerificationError wraps them, so a check for it would match
+	// them all.
+	var authorityErr x509.UnknownAuthorityError
+	var hostnameErr x509.HostnameError
+	var certInvalidErr x509.CertificateInvalidError
+	var certErr *tls.CertificateVerificationError
+	switch {
+	case errors.As(err, &authorityErr):
+		return errTLSCertificateUntrusted
+	case errors.As(err, &hostnameErr):
+		return errTLSCertificateHostname
+	case errors.As(err, &certInvalidErr):
+		if certInvalidErr.Reason == x509.Expired {
+			return errTLSCertificateExpired
+		}
+		return errTLSCertificate
+	case errors.As(err, &certErr):
+		return errTLSCertificate
+	}
+
+	// Not TLS on the other side at all. crypto/tls reports this as a record
+	// header error, which [http.Client] replaces with [http.ErrSchemeMismatch]
+	// when the bytes it saw are an HTTP response, so both spellings have to be
+	// caught.
+	var recordErr tls.RecordHeaderError
+	if errors.As(err, &recordErr) || errors.Is(err, http.ErrSchemeMismatch) {
+		return errTLSPlaintext
+	}
+
+	// An alert. tls.AlertError is only produced over QUIC; a TLS connection
+	// surfaces the alert it received as a net.OpError with Op "remote error"
+	// wrapping an unexported type, so its message is all there is to match on.
+	// "remote error" plus a certificate is the far end rejecting ours — the
+	// gateway-to-gateway mTLS credential, on the forwarding hop.
+	var alertErr tls.AlertError
+	if errors.As(err, &alertErr) {
+		return errTLS
+	}
+	if opErr != nil && (opErr.Op == "remote error" || opErr.Op == "local error") {
+		if opErr.Op == "remote error" && opErr.Err != nil && strings.Contains(opErr.Err.Error(), "certificate") {
+			return errTLSClientCertRejected
+		}
+		return errTLS
+	}
+
+	// net/http's stalled-handshake error is an unexported type whose only
+	// distinguishing feature is its message.
+	if strings.Contains(err.Error(), "TLS handshake timeout") {
+		return errTLSHandshakeTimeout
+	}
+	return ""
+}
+
+// syscallErrorType classifies the kernel-level network errors, or returns the
+// empty string for anything else.
+func syscallErrorType(err error) string {
+	switch {
+	case errors.Is(err, syscall.ECONNREFUSED):
+		return errConnectionRefused
+	case errors.Is(err, syscall.ECONNRESET), errors.Is(err, syscall.ECONNABORTED):
+		return errConnectionReset
+	case errors.Is(err, syscall.EPIPE):
+		return errBrokenPipe
+	case errors.Is(err, syscall.EHOSTUNREACH), errors.Is(err, syscall.EHOSTDOWN):
+		return errHostUnreachable
+	case errors.Is(err, syscall.ENETUNREACH), errors.Is(err, syscall.ENETDOWN):
+		return errNetworkUnreachable
+	case errors.Is(err, syscall.EADDRNOTAVAIL), errors.Is(err, syscall.EADDRINUSE),
+		errors.Is(err, syscall.EMFILE), errors.Is(err, syscall.ENFILE):
+		return errLocalResourceExhausted
+	}
+	return ""
+}
+
+// http2ErrorType classifies the HTTP/2 conditions that matter on a long-lived
+// multiplexed connection — the one the forwarding hop pins for its life. The
+// HTTP/2 implementation net/http bundles keeps its error types unexported, so
+// matching the message is the only option; an unrecognized message simply falls
+// through to the general classification.
+func http2ErrorType(err error) string {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "GOAWAY"):
+		return errHTTP2GoAway
+	case strings.Contains(msg, "stream error:"):
+		return errHTTP2Stream
+	}
+	return ""
 }
 
 // statusErrorType maps an upstream response status to an error.type, or to the
@@ -238,7 +440,9 @@ func authErrorType(err error) string {
 // transferErrorType classifies a failure that happened while streaming a
 // response body to the client. io.Copy cannot say whether the upstream read or
 // the client write failed, so an unrecognized cause is reported as an aborted
-// transfer rather than guessed at.
+// transfer rather than guessed at. The classifier does distinguish the two most
+// common recognizable halves: a broken pipe is a client that hung up, and an
+// unexpected EOF is an upstream that stopped short of its Content-Length.
 func transferErrorType(err error) string {
 	if t := transportErrorType(err); t != errTypeUnknown {
 		return t

--- a/img_tool/pkg/serve/gateway/errclass_test.go
+++ b/img_tool/pkg/serve/gateway/errclass_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -31,21 +32,89 @@ func TestTransportErrorType(t *testing.T) {
 			want: errConnectionRefused,
 		},
 		{"connection reset", &net.OpError{Op: "read", Err: syscall.ECONNRESET}, errConnectionReset},
-		{"broken pipe", &net.OpError{Op: "write", Err: syscall.EPIPE}, errConnectionReset},
-		{"host unreachable", &net.OpError{Op: "dial", Err: syscall.EHOSTUNREACH}, errNetworkUnreachable},
+		{"connection aborted", &net.OpError{Op: "read", Err: syscall.ECONNABORTED}, errConnectionReset},
+		// A client that hung up mid-response is not an upstream problem, so it
+		// does not share a bucket with a reset.
+		{"broken pipe", &net.OpError{Op: "write", Err: syscall.EPIPE}, errBrokenPipe},
+		{"host unreachable", &net.OpError{Op: "dial", Err: syscall.EHOSTUNREACH}, errHostUnreachable},
 		{"network unreachable", &net.OpError{Op: "dial", Err: syscall.ENETUNREACH}, errNetworkUnreachable},
+		{"out of local ports", &net.OpError{Op: "dial", Err: syscall.EADDRNOTAVAIL}, errLocalResourceExhausted},
+		{"out of file descriptors", &os.SyscallError{Syscall: "socket", Err: syscall.EMFILE}, errLocalResourceExhausted},
 		{"context deadline", fmt.Errorf("forwarding: %w", context.DeadlineExceeded), errTimeout},
-		{"i/o timeout", &net.OpError{Op: "read", Err: os.ErrDeadlineExceeded}, errTimeout},
+		// A timeout is attributed to the stage that timed out: a connect that
+		// never completed is a dropped packet, a read that did is a stalled
+		// upstream, and a write that did is backpressure.
+		{"connect timeout", &net.OpError{Op: "dial", Err: os.ErrDeadlineExceeded}, errDialTimeout},
+		{"i/o timeout", &net.OpError{Op: "read", Err: os.ErrDeadlineExceeded}, errReadTimeout},
+		{"write timeout", &net.OpError{Op: "write", Err: os.ErrDeadlineExceeded}, errWriteTimeout},
+		{"handshake timeout", &url.Error{Op: "Get", Err: errors.New("net/http: TLS handshake timeout")}, errTLSHandshakeTimeout},
 		{"client went away", fmt.Errorf("copying: %w", context.Canceled), errClientCanceled},
-		{"name resolution", &net.DNSError{Err: "no such host", Name: "registry.test", IsNotFound: true}, errDNS},
+		{"name does not exist", &net.DNSError{Err: "no such host", Name: "registry.test", IsNotFound: true}, errDNSNotFound},
+		{"resolver did not answer", &net.DNSError{Err: "i/o timeout", Name: "registry.test", IsTimeout: true}, errDNSTimeout},
+		{"resolution failed", &net.DNSError{Err: "server misbehaving", Name: "registry.test"}, errDNS},
+		// Reaching the proxy is a different address to debug than reaching the
+		// registry, so it keeps its own type whatever the underlying cause.
+		{
+			name: "proxy unreachable",
+			err:  &url.Error{Op: "Get", Err: &net.OpError{Op: "proxyconnect", Net: "tcp", Err: syscall.ECONNREFUSED}},
+			want: errProxyConnect,
+		},
 		{
 			name: "untrusted certificate",
 			err:  &url.Error{Op: "Get", Err: &tls.CertificateVerificationError{Err: x509.UnknownAuthorityError{}}},
+			want: errTLSCertificateUntrusted,
+		},
+		{
+			name: "expired certificate",
+			err:  &tls.CertificateVerificationError{Err: x509.CertificateInvalidError{Reason: x509.Expired}},
+			want: errTLSCertificateExpired,
+		},
+		{
+			name: "otherwise invalid certificate",
+			err:  x509.CertificateInvalidError{Reason: x509.IncompatibleUsage},
 			want: errTLSCertificate,
 		},
-		{"certificate for the wrong host", x509.HostnameError{Host: "registry.test"}, errTLSCertificate},
-		{"not a TLS server", tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}, errTLS},
+		{"certificate for the wrong host", x509.HostnameError{Host: "registry.test"}, errTLSCertificateHostname},
+		{"not a TLS server", tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}, errTLSPlaintext},
+		{
+			// What net/http substitutes for the record header error when the
+			// bytes it saw are an HTTP response.
+			name: "plain HTTP on an HTTPS port",
+			err:  &url.Error{Op: "Get", Err: http.ErrSchemeMismatch},
+			want: errTLSPlaintext,
+		},
+		{
+			// The far end rejecting our client certificate: the mTLS credential
+			// on the gateway-to-gateway hop, which used to look like a generic
+			// network failure.
+			name: "peer rejected our client certificate",
+			err:  &url.Error{Op: "Get", Err: &net.OpError{Op: "remote error", Err: errors.New("tls: bad certificate")}},
+			want: errTLSClientCertRejected,
+		},
+		{
+			name: "peer requires a client certificate",
+			err:  &net.OpError{Op: "remote error", Err: errors.New("tls: certificate required")},
+			want: errTLSClientCertRejected,
+		},
+		{
+			name: "handshake alert that is not about a certificate",
+			err:  &net.OpError{Op: "remote error", Err: errors.New("tls: handshake failure")},
+			want: errTLS,
+		},
 		{"TLS alert", tls.AlertError(80), errTLS},
+		{"truncated body", fmt.Errorf("reading body: %w", io.ErrUnexpectedEOF), errUnexpectedEOF},
+		{
+			// The connection a forwarding gateway pins to its peer, taken away
+			// by a rolling restart or a service mesh's max connection age.
+			name: "peer sent GOAWAY",
+			err:  errors.New("http2: server sent GOAWAY and closed the connection; LastStreamID=1, ErrCode=NO_ERROR, debug=\"\""),
+			want: errHTTP2GoAway,
+		},
+		{
+			name: "stream refused",
+			err:  errors.New("stream error: stream ID 3; REFUSED_STREAM"),
+			want: errHTTP2Stream,
+		},
 		{"generic network failure", &net.OpError{Op: "dial", Err: errors.New("boom")}, errNetwork},
 		{"upstream 401", &transport.Error{StatusCode: http.StatusUnauthorized}, errUpstreamUnauthorized},
 		{"upstream 403", &transport.Error{StatusCode: http.StatusForbidden}, errUpstreamForbidden},
@@ -114,7 +183,141 @@ func TestAuthAndTransferErrorTypes(t *testing.T) {
 	if got := transferErrorType(&net.OpError{Op: "write", Err: syscall.ECONNRESET}); got != errConnectionReset {
 		t.Errorf("transferErrorType(reset) = %q, want %q", got, errConnectionReset)
 	}
+	// A body that stopped short of its Content-Length says the content is
+	// truncated, which an aborted transfer alone does not.
+	if got := transferErrorType(io.ErrUnexpectedEOF); got != errUnexpectedEOF {
+		t.Errorf("transferErrorType(unexpected EOF) = %q, want %q", got, errUnexpectedEOF)
+	}
 	if got := transferErrorType(errors.New("unexpected EOF")); got != errTransferAborted {
 		t.Errorf("transferErrorType(EOF) = %q, want %q", got, errTransferAborted)
+	}
+}
+
+// TestTLSErrorTypesAgainstRealHandshakes runs the TLS classifications against
+// what crypto/tls and net/http actually produce, rather than against errors the
+// test constructed. That is what makes them worth asserting: the failures below
+// arrive as unexported types or as plain errors, so the classifier matches on a
+// message or on a net.OpError's Op, and only a real handshake can confirm the
+// match still holds.
+func TestTLSErrorTypesAgainstRealHandshakes(t *testing.T) {
+	serverCA := newTestCA(t, "server-ca")
+	serverCertPEM, serverKeyPEM, _ := serverCA.issue(t, leafOptions{commonName: "gateway.test", dnsNames: []string{"gateway.test"}, server: true})
+	serverCert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
+	if err != nil {
+		t.Fatalf("loading server keypair: %v", err)
+	}
+	serverRoots := x509.NewCertPool()
+	serverRoots.AddCert(serverCA.cert)
+
+	// A client certificate from a CA the server does not trust: the mTLS
+	// credential mismatch of the gateway-to-gateway hop.
+	clientCA := newTestCA(t, "client-ca")
+	clientCertPEM, clientKeyPEM, _ := clientCA.issue(t, leafOptions{commonName: "forwarder"})
+	clientCert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
+	if err != nil {
+		t.Fatalf("loading client keypair: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		// serve handles the server side of one connection.
+		serve func(conn net.Conn)
+		// client is the configuration the gateway would dial with.
+		client *tls.Config
+		want   string
+	}{
+		{
+			name: "the peer rejects our client certificate",
+			serve: func(conn net.Conn) {
+				// Requires a client certificate, trusts only its own CA.
+				server := tls.Server(conn, &tls.Config{
+					Certificates: []tls.Certificate{serverCert},
+					ClientAuth:   tls.RequireAndVerifyClientCert,
+					ClientCAs:    x509.NewCertPool(),
+				})
+				_ = server.Handshake()
+			},
+			client: &tls.Config{
+				RootCAs:      serverRoots,
+				ServerName:   "gateway.test",
+				Certificates: []tls.Certificate{clientCert},
+			},
+			want: errTLSClientCertRejected,
+		},
+		{
+			name: "the peer demands a client certificate we do not have",
+			serve: func(conn net.Conn) {
+				server := tls.Server(conn, &tls.Config{
+					Certificates: []tls.Certificate{serverCert},
+					ClientAuth:   tls.RequireAnyClientCert,
+				})
+				_ = server.Handshake()
+			},
+			client: &tls.Config{RootCAs: serverRoots, ServerName: "gateway.test"},
+			want:   errTLSClientCertRejected,
+		},
+		{
+			name: "we do not trust the peer's certificate",
+			serve: func(conn net.Conn) {
+				server := tls.Server(conn, &tls.Config{Certificates: []tls.Certificate{serverCert}})
+				_ = server.Handshake()
+			},
+			client: &tls.Config{RootCAs: x509.NewCertPool(), ServerName: "gateway.test"},
+			want:   errTLSCertificateUntrusted,
+		},
+		{
+			name: "the peer's certificate is for another name",
+			serve: func(conn net.Conn) {
+				server := tls.Server(conn, &tls.Config{Certificates: []tls.Certificate{serverCert}})
+				_ = server.Handshake()
+			},
+			client: &tls.Config{RootCAs: serverRoots, ServerName: "elsewhere.test"},
+			want:   errTLSCertificateHostname,
+		},
+		{
+			name: "the endpoint is not speaking TLS",
+			serve: func(conn net.Conn) {
+				// Read the ClientHello and answer it with a plain HTTP
+				// response, the way an http:// service on an https:// port
+				// would. The connection stays open: closing it here would
+				// fail the client's write before it ever read the reply.
+				_, _ = conn.Read(make([]byte, 1024))
+				_, _ = io.WriteString(conn, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+			},
+			client: &tls.Config{RootCAs: serverRoots, ServerName: "gateway.test"},
+			want:   errTLSPlaintext,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clientConn, server := memPipe("tls")
+			// The server side never closes: under TLS 1.3 the client's
+			// handshake completes before the server has even seen its
+			// certificate, so the rejection alert is read during the request
+			// that follows. A close here would race that read and surface as
+			// "use of closed network connection" instead.
+			t.Cleanup(func() { _, _ = clientConn.Close(), server.Close() })
+			go tc.serve(server)
+
+			// Dial through an http.Client, so the error is wrapped exactly as it
+			// would be in the gateway: net/http substitutes its own error for
+			// some of these before the caller ever sees the tls package's.
+			client := &http.Client{Transport: &http.Transport{
+				DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					conn := tls.Client(clientConn, tc.client)
+					if err := conn.HandshakeContext(ctx); err != nil {
+						return nil, err
+					}
+					return conn, nil
+				},
+			}}
+			resp, err := client.Get("https://gateway.test/v2/")
+			if err == nil {
+				resp.Body.Close()
+				t.Fatal("handshake succeeded, want a failure to classify")
+			}
+			if got := transportErrorType(err); got != tc.want {
+				t.Errorf("transportErrorType(%v) = %q, want %q", err, got, tc.want)
+			}
+		})
 	}
 }

--- a/img_tool/pkg/serve/gateway/metrics_test.go
+++ b/img_tool/pkg/serve/gateway/metrics_test.go
@@ -487,7 +487,7 @@ func TestMetricsErrorTypes(t *testing.T) {
 			method:       http.MethodGet,
 			host:         testUpstreamHost,
 			target:       "/v2/app/blobs/sha256:abc",
-			want:         errDNS,
+			want:         errDNSNotFound,
 			wantRegistry: testUpstreamHost,
 		},
 	} {


### PR DESCRIPTION
Before this change, the gateway put almost all network problems into three values of `error.type`: `network`, `timeout`, and `tls`. These values tell the operator that a request failed. They do not tell the operator where to look.

Each network value now also gives the stage of the connection that failed:

- **The name resolution stage** adds `dns_not_found` and `dns_timeout`.
- **The connect stage** adds `host_unreachable`, `dial_timeout`, `proxy_connect`, and `local_resource_exhausted`.
- **The TLS stage** adds `tls_certificate_untrusted`, `tls_certificate_expired`, `tls_certificate_hostname`, `tls_client_certificate_rejected`, `tls_plaintext`, and `tls_handshake_timeout`.
- **An open connection** adds `broken_pipe`, `unexpected_eof`, `read_timeout`, `write_timeout`, `http2_goaway`, and `http2_stream`.

Each stage keeps a general value. Thus the classifier always has a value for a cause that it cannot identify.

Two of the old values were incorrect, and not only unclear. When a peer refused the mTLS client certificate of the gateway, the gateway recorded `network`. Crypto/tls gives such an alert as a `net.OpError` with the operation `remote error`:

```
remote error: tls: bad certificate
```

A client that closed the connection during a response also looked the same as a reset from the upstream registry.

The classifier now examines the error in the sequence of the connection. It reports the first cause that it finds. All network errors are a `net.OpError`, and this general match no longer hides an exact cause. The value `proxy_connect` is an exception. It replaces its own cause, because the operator must debug a different address.

Some of these errors have no exported type. For these errors, the classifier compares the text of the message. A new test does true TLS handshakes on an in-memory connection. The test makes sure that the classifier agrees with crypto/tls and net/http.

The metrics section of the gateway README lists the new values by stage. It also gives PromQL queries for each stage, and an alert for the three values that always show a configuration error.
