### PR TITLE
perf: use symbolic links for sparse layouts and CAS directories

### DIFF
--- a/img/private/BUILD.bazel
+++ b/img/private/BUILD.bazel
@@ -27,7 +27,7 @@ bzl_library(
     visibility = ["//img:__subpackages__"],
     deps = [
         "//img/private/common:build",
-        "@bazel_features//:features",
+        "//img/private/common:tree_symlinks",
     ],
 )
 
@@ -43,6 +43,7 @@ bzl_library(
         "//img:providers",
         "//img/private/common:build",
         "//img/private/common:transitions",
+        "//img/private/common:tree_symlinks",
         "//img/private/common:write_index_json",
         "//img/private/providers:load_config_info",
         "//img/private/providers:oci_layout_settings_info",
@@ -171,6 +172,7 @@ bzl_library(
         "//img/private/common:inherit",
         "//img/private/common:layer_helper",
         "//img/private/common:transitions",
+        "//img/private/common:tree_symlinks",
         "//img/private/config:defs",
         "//img/private/providers:index_info",
         "//img/private/providers:layer_config_info",

--- a/img/private/common/BUILD.bazel
+++ b/img/private/common/BUILD.bazel
@@ -69,7 +69,10 @@ bzl_library(
     name = "sparse_oci_layout",
     srcs = ["sparse_oci_layout.bzl"],
     visibility = ["//img:__subpackages__"],
-    deps = [":build"],
+    deps = [
+        ":build",
+        ":tree_symlinks",
+    ],
 )
 
 bzl_library(
@@ -79,11 +82,19 @@ bzl_library(
     deps = [
         ":build",
         ":layer_helper",
+        ":tree_symlinks",
         "//img/private/providers:layers_info",
         "//img/private/providers:single_layer_info",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//rules:common_settings",
     ],
+)
+
+bzl_library(
+    name = "tree_symlinks",
+    srcs = ["tree_symlinks.bzl"],
+    visibility = ["//img:__subpackages__"],
+    deps = ["@bazel_features//:features"],
 )
 
 bzl_library(

--- a/img/private/common/sparse_oci_layout.bzl
+++ b/img/private/common/sparse_oci_layout.bzl
@@ -1,6 +1,7 @@
 """Shared sparse OCI layout builder functions."""
 
 load(":build.bzl", "TOOLCHAIN")
+load(":tree_symlinks.bzl", "use_tree_symlinks")
 
 def build_sparse_oci_layout_for_manifest(ctx, manifest_out, config_out, layers, suffix = ""):
     """Build a sparse OCI layout tree artifact for a single-platform manifest.
@@ -34,6 +35,8 @@ def build_sparse_oci_layout_for_manifest(ctx, manifest_out, config_out, layers, 
             inputs.append(layer.compact_stream)
 
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    if use_tree_symlinks(img_toolchain_info.tool_exe):
+        args.add("--symlink")
     ctx.actions.run(
         inputs = inputs,
         outputs = [output],
@@ -79,6 +82,8 @@ def build_sparse_oci_layout_for_index(ctx, index_out, manifests):
                 inputs.append(layer.compact_stream)
 
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    if use_tree_symlinks(img_toolchain_info.tool_exe):
+        args.add("--symlink")
     ctx.actions.run(
         inputs = inputs,
         outputs = [output],

--- a/img/private/common/tar_layer.bzl
+++ b/img/private/common/tar_layer.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//img/private/common:build.bzl", "TOOLCHAIN")
 load("//img/private/common:layer_helper.bzl", "build_layer_mtree", "compression_tuning_args", "layer_history", "layer_name")
+load("//img/private/common:tree_symlinks.bzl", "use_tree_symlinks")
 load("//img/private/providers:layers_info.bzl", "LayersInfo")
 load("//img/private/providers:single_layer_info.bzl", "SingleLayerInfo")
 
@@ -406,6 +407,10 @@ def _build_input_files_cas(ctx, name, extra_inputs):
     the layer), expanding tree artifacts and skipping pure symlinks (which carry
     no content blob). The resulting tree artifact lets a layer be reconstructed
     from its compact stream without materializing the layer blob.
+
+    Where the exec platform and Bazel version allow it, the entries are relative
+    symlinks to the input files instead of copies, so a layer's inputs are not
+    materialized twice (see use_tree_symlinks).
     """
     output_dir = ctx.actions.declare_directory(name + ".inputfilecas")
     input_files = depset(transitive = extra_inputs)
@@ -420,6 +425,8 @@ def _build_input_files_cas(ctx, name, extra_inputs):
     args.add("--output", output_dir.path)
 
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    if use_tree_symlinks(img_toolchain_info.tool_exe):
+        args.add("--symlink")
     ctx.actions.run(
         outputs = [output_dir],
         inputs = input_files,

--- a/img/private/common/tree_symlinks.bzl
+++ b/img/private/common/tree_symlinks.bzl
@@ -1,0 +1,32 @@
+"""Gate for referencing an action's inputs from a tree artifact with symlinks."""
+
+load("@bazel_features//:features.bzl", "bazel_features")
+
+def use_tree_symlinks(tool):
+    """Reports whether a directory output may reference its inputs via relative symlinks.
+
+    Actions that only copy files into a tree artifact can instead emit relative
+    symlinks to the input files, so content shared between outputs (base image
+    blobs, layer input files) is referenced rather than re-materialized per
+    output. Bazel 7.1 is the first version that permits symlinks pointing
+    outside of a tree artifact (bazelbuild/bazel#21263), and the symlinks must
+    be relative to stay valid under remote execution and in runfiles trees.
+
+    Symlinks are skipped on Windows exec platforms: Windows hardlinks to reparse
+    points propagate the (now-misplaced) relative target to the new file, turning
+    it into a dangling symlink when downstream tools copy files out of the tree.
+
+    Only ask for directory (tree artifact) outputs -- tar outputs always embed
+    their content.
+
+    Args:
+        tool: The executable File the action runs, used to detect the exec platform.
+
+    Returns:
+        True if the action should be asked to emit symlinks instead of copies.
+    """
+
+    # The img tool is img.exe on Windows exec platforms and img elsewhere.
+    if tool.basename.endswith(".exe"):
+        return False
+    return bazel_features.rules.permits_treeartifact_uplevel_symlinks

--- a/img/private/index.bzl
+++ b/img/private/index.bzl
@@ -7,6 +7,7 @@ load("//img/private:soci_deploy.bzl", "soci_deploy_children")
 load("//img/private:stamp.bzl", "expand_or_write")
 load("//img/private/common:build.bzl", "TOOLCHAIN", "TOOLCHAINS")
 load("//img/private/common:transitions.bzl", "multi_platform_image_transition", "reset_platform_transition")
+load("//img/private/common:tree_symlinks.bzl", "use_tree_symlinks")
 load("//img/private/common:write_index_json.bzl", "write_index_json")
 load("//img/private/providers:index_info.bzl", "ImageIndexInfo")
 load("//img/private/providers:load_config_info.bzl", "LoadConfigInfo")
@@ -121,6 +122,8 @@ def _build_sparse_oci_layout(ctx, format, index_out, manifests):
         inputs.append(child.config)
 
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    if format == "directory" and use_tree_symlinks(img_toolchain_info.tool_exe):
+        args.add("--symlink")
     ctx.actions.run(
         inputs = inputs,
         outputs = [output],

--- a/img/private/manifest.bzl
+++ b/img/private/manifest.bzl
@@ -9,6 +9,7 @@ load("//img/private/common:build.bzl", "TOOLCHAIN", "TOOLCHAINS")
 load("//img/private/common:inherit.bzl", "INHERIT_FROM_BASE")
 load("//img/private/common:layer_helper.bzl", "allow_tar_files", "build_image_mtree", "calculate_layer_info", "extension_to_compression", "image_layer_mtrees", "image_layer_ztocs")
 load("//img/private/common:transitions.bzl", "normalize_layer_transition", "single_platform_transition")
+load("//img/private/common:tree_symlinks.bzl", "use_tree_symlinks")
 load("//img/private/config:defs.bzl", "TargetPlatformInfo")
 load("//img/private/providers:index_info.bzl", "ImageIndexInfo")
 load("//img/private/providers:layer_config_info.bzl", "ImageLayerConfigInfo")
@@ -296,6 +297,8 @@ def _build_sparse_oci_layout(ctx, format, manifest_out, config_out, layers):
             inputs.append(layer.compact_stream)
 
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    if format == "directory" and use_tree_symlinks(img_toolchain_info.tool_exe):
+        args.add("--symlink")
     ctx.actions.run(
         inputs = inputs,
         outputs = [output],

--- a/img/private/oci_layout_action.bzl
+++ b/img/private/oci_layout_action.bzl
@@ -1,19 +1,15 @@
 """Shared helper to run img oci-layout with optional uplevel symlinks."""
 
-load("@bazel_features//:features.bzl", "bazel_features")
 load("//img/private/common:build.bzl", "TOOLCHAIN")
+load("//img/private/common:tree_symlinks.bzl", "use_tree_symlinks")
 
 def run_oci_layout_action(ctx, *, format, output, args, inputs, mnemonic):
     """Run `img oci-layout`, emitting relative symlinks for directory outputs on Bazel >= 7.1.
 
     Directory TreeArtifact outputs use --symlink so that shared base-image blobs
     are symlinked rather than copied into every layout, matching rules_oci's
-    shared-base model.  The img tool produces relative symlinks, which are safe
-    under remote execution and runfiles trees.  Tar outputs always embed blobs.
-
-    Symlinks are skipped on Windows exec platforms: Windows hardlinks to reparse
-    points propagate the (now-misplaced) relative target to the new file, turning
-    it into a dangling symlink when downstream tools copy blobs out of the tree.
+    shared-base model (see use_tree_symlinks for when this applies).  Tar outputs
+    always embed blobs.
 
     Args:
         ctx: Rule context.
@@ -26,10 +22,7 @@ def run_oci_layout_action(ctx, *, format, output, args, inputs, mnemonic):
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
     tool = img_toolchain_info.tool_exe
 
-    # The img tool is img.exe on Windows exec platforms and img elsewhere.
-    is_windows_exec = tool.basename.endswith(".exe")
-
-    if format == "directory" and not is_windows_exec and bazel_features.rules.permits_treeartifact_uplevel_symlinks:
+    if format == "directory" and use_tree_symlinks(tool):
         args.add("--symlink")
 
     args.add("--output", output.path)

--- a/img_tool/cmd/casdir/BUILD.bazel
+++ b/img_tool/cmd/casdir/BUILD.bazel
@@ -1,8 +1,14 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "casdir",
     srcs = ["casdir.go"],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/cmd/casdir",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "casdir_test",
+    srcs = ["casdir_test.go"],
+    embed = [":casdir"],
 )

--- a/img_tool/cmd/casdir/casdir.go
+++ b/img_tool/cmd/casdir/casdir.go
@@ -4,6 +4,9 @@
 // deduplicating identical content. Symlinks and unreadable entries are skipped —
 // they carry no content blob.
 //
+// With --symlink, entries are relative symlinks to the input files instead of
+// copies of their content, so the inputs are not materialized a second time.
+//
 // The resulting directory is used to reconstruct a layer tar from its CAS stream
 // index: each CAS reference (addressed by the sha256 of its content) is resolved
 // by opening <dir>/sha256/<hex>.
@@ -34,6 +37,7 @@ func (s *stringSliceFlag) Set(value string) error {
 func CASDirProcess(_ context.Context, args []string) {
 	var outputDir string
 	var fromFiles stringSliceFlag
+	var useSymlinks bool
 
 	flagSet := flag.NewFlagSet("cas-dir", flag.ExitOnError)
 	flagSet.Usage = func() {
@@ -43,6 +47,7 @@ func CASDirProcess(_ context.Context, args []string) {
 	}
 	flagSet.StringVar(&outputDir, "output", "", "Output directory for the content-addressed store (required)")
 	flagSet.Var(&fromFiles, "from-file", "Path to a newline-delimited file listing input files/directories (repeatable)")
+	flagSet.BoolVar(&useSymlinks, "symlink", false, "Use symlinks instead of copying files")
 
 	if err := flagSet.Parse(args); err != nil {
 		flagSet.Usage()
@@ -64,7 +69,7 @@ func CASDirProcess(_ context.Context, args []string) {
 		inputs = append(inputs, paths...)
 	}
 
-	w := &casWriter{shaDir: filepath.Join(outputDir, "sha256")}
+	w := &casWriter{shaDir: filepath.Join(outputDir, "sha256"), useSymlinks: useSymlinks}
 	if err := os.MkdirAll(w.shaDir, 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating output directory: %v\n", err)
 		os.Exit(1)
@@ -78,7 +83,8 @@ func CASDirProcess(_ context.Context, args []string) {
 }
 
 type casWriter struct {
-	shaDir string
+	shaDir      string
+	useSymlinks bool
 }
 
 // addPath adds a file, or every regular file within a directory, to the store.
@@ -110,9 +116,60 @@ func (w *casWriter) addPath(p string) error {
 	return nil
 }
 
-// addFile streams the file once through a hash and a temp file, then renames the
-// temp file to its content-addressed name. Identical content is deduplicated.
+// addFile stores the file under its content-addressed name, either as a relative
+// symlink to it or as a copy of its content.
 func (w *casWriter) addFile(filePath string) error {
+	if w.useSymlinks {
+		return w.linkFile(filePath)
+	}
+	return w.copyFile(filePath)
+}
+
+// linkFile hashes the file's content and places a relative symlink to it at its
+// content-addressed name, so the content is referenced instead of duplicated.
+// The target must be relative: the store is a Bazel tree artifact, and only
+// relative symlinks stay valid wherever the tree is staged (sandbox, remote
+// execution, runfiles tree).
+func (w *casWriter) linkFile(filePath string) error {
+	src, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", filePath, err)
+	}
+	h := sha256.New()
+	_, err = io.Copy(h, src)
+	src.Close()
+	if err != nil {
+		return fmt.Errorf("hashing %s: %w", filePath, err)
+	}
+
+	dest := filepath.Join(w.shaDir, hex.EncodeToString(h.Sum(nil)))
+	if _, err := os.Lstat(dest); err == nil {
+		// Already stored (deduplicated).
+		return nil
+	}
+	target, err := relativeTarget(filePath, dest)
+	if err != nil {
+		return fmt.Errorf("relative path from %s to %s: %w", dest, filePath, err)
+	}
+	return os.Symlink(target, dest)
+}
+
+// relativeTarget returns src as a path relative to the directory holding dst.
+func relativeTarget(src, dst string) (string, error) {
+	absSrc, err := filepath.Abs(src)
+	if err != nil {
+		return "", err
+	}
+	absDst, err := filepath.Abs(dst)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Rel(filepath.Dir(absDst), absSrc)
+}
+
+// copyFile streams the file once through a hash and a temp file, then renames the
+// temp file to its content-addressed name. Identical content is deduplicated.
+func (w *casWriter) copyFile(filePath string) error {
 	src, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", filePath, err)

--- a/img_tool/cmd/casdir/casdir_test.go
+++ b/img_tool/cmd/casdir/casdir_test.go
@@ -1,0 +1,128 @@
+package casdir
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func hexOf(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+// newWriter returns a writer storing into <dir>/out/sha256, mirroring what
+// CASDirProcess sets up.
+func newWriter(t *testing.T, dir string, useSymlinks bool) *casWriter {
+	t.Helper()
+	shaDir := filepath.Join(dir, "out", "sha256")
+	if err := os.MkdirAll(shaDir, 0o755); err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	return &casWriter{shaDir: shaDir, useSymlinks: useSymlinks}
+}
+
+func writeFile(t *testing.T, path, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("creating dir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+func TestCASDirCopies(t *testing.T) {
+	dir := t.TempDir()
+	w := newWriter(t, dir, false)
+	src := writeFile(t, filepath.Join(dir, "src", "file"), "content")
+
+	if err := w.addPath(src); err != nil {
+		t.Fatalf("addPath: %v", err)
+	}
+
+	dest := filepath.Join(w.shaDir, hexOf("content"))
+	info, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dest, err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Errorf("entry mode: got %v, want a regular file", info.Mode())
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dest, err)
+	}
+	if string(got) != "content" {
+		t.Errorf("stored content: got %q, want %q", got, "content")
+	}
+}
+
+func TestCASDirSymlinksAreRelative(t *testing.T) {
+	dir := t.TempDir()
+	w := newWriter(t, dir, true)
+	src := writeFile(t, filepath.Join(dir, "src", "file"), "content")
+
+	if err := w.addPath(src); err != nil {
+		t.Fatalf("addPath: %v", err)
+	}
+
+	dest := filepath.Join(w.shaDir, hexOf("content"))
+	target, err := os.Readlink(dest)
+	if err != nil {
+		t.Fatalf("reading symlink %s: %v", dest, err)
+	}
+	if filepath.IsAbs(target) {
+		t.Errorf("symlink target must be relative, got %q", target)
+	}
+	// The relative target must resolve to the original source file.
+	if resolved := filepath.Join(filepath.Dir(dest), target); resolved != src {
+		t.Errorf("resolved symlink: got %q, want %q", resolved, src)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("reading through symlink %s: %v", dest, err)
+	}
+	if string(got) != "content" {
+		t.Errorf("content through symlink: got %q, want %q", got, "content")
+	}
+}
+
+// Walking a directory must link every regular file it contains, and identical
+// content must be stored (linked) only once.
+func TestCASDirSymlinkDirectoryAndDedup(t *testing.T) {
+	dir := t.TempDir()
+	w := newWriter(t, dir, true)
+	srcDir := filepath.Join(dir, "src")
+	writeFile(t, filepath.Join(srcDir, "first"), "shared")
+	writeFile(t, filepath.Join(srcDir, "nested", "second"), "shared")
+	writeFile(t, filepath.Join(srcDir, "nested", "third"), "other")
+
+	if err := w.addPath(srcDir); err != nil {
+		t.Fatalf("addPath: %v", err)
+	}
+
+	entries, err := os.ReadDir(w.shaDir)
+	if err != nil {
+		t.Fatalf("reading store: %v", err)
+	}
+	if len(entries) != 2 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("store entries: got %v, want the 2 distinct contents", names)
+	}
+	for _, content := range []string{"shared", "other"} {
+		got, err := os.ReadFile(filepath.Join(w.shaDir, hexOf(content)))
+		if err != nil {
+			t.Fatalf("reading entry for %q: %v", content, err)
+		}
+		if string(got) != content {
+			t.Errorf("entry for %q: got %q", content, got)
+		}
+	}
+}

--- a/img_tool/cmd/sparseocilayout/sparseocilayout.go
+++ b/img_tool/cmd/sparseocilayout/sparseocilayout.go
@@ -22,6 +22,7 @@ func SparseOCILayoutProcess(ctx context.Context, args []string) {
 	var layerCompactStreamFlags layerMappingFlag
 	var manifestPaths stringSliceFlag
 	var configPaths stringSliceFlag
+	var useSymlinks bool
 	var format string
 
 	flagSet := flag.NewFlagSet("sparse-oci-layout", flag.ExitOnError)
@@ -42,6 +43,7 @@ func SparseOCILayoutProcess(ctx context.Context, args []string) {
 	flagSet.Var(&layerCompactStreamFlags, "layer-compact-stream", "Layer compact stream as <metadata_path>=<cstream_path> (can be specified multiple times)")
 	flagSet.Var(&manifestPaths, "manifest-path", "Path to manifest file (for index, can be specified multiple times)")
 	flagSet.Var(&configPaths, "config-path", "Path to config file (for index, can be specified multiple times)")
+	flagSet.BoolVar(&useSymlinks, "symlink", false, "Use symlinks instead of copying files")
 
 	if err := flagSet.Parse(args); err != nil {
 		flagSet.Usage()
@@ -74,7 +76,7 @@ func SparseOCILayoutProcess(ctx context.Context, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: --index requires at least one --manifest-path and --config-path\n")
 			os.Exit(1)
 		}
-		err = assembleSparseLayoutWithIndex(ctx, indexPath, outputDir, format, manifestPaths, configPaths, layerFlags, layerCompactStreamFlags)
+		err = assembleSparseLayoutWithIndex(ctx, indexPath, outputDir, format, manifestPaths, configPaths, layerFlags, layerCompactStreamFlags, useSymlinks)
 	} else {
 		if manifestPath == "" {
 			fmt.Fprintf(os.Stderr, "Error: either --manifest or --index is required\n")
@@ -90,7 +92,7 @@ func SparseOCILayoutProcess(ctx context.Context, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: cannot use --manifest-path or --config-path without --index\n")
 			os.Exit(1)
 		}
-		err = assembleSparseLayout(ctx, manifestPath, configPath, outputDir, format, layerFlags, layerCompactStreamFlags)
+		err = assembleSparseLayout(ctx, manifestPath, configPath, outputDir, format, layerFlags, layerCompactStreamFlags, useSymlinks)
 	}
 
 	if err != nil {
@@ -166,7 +168,7 @@ func writeLayout(ctx context.Context, b *ocilayout.Builder, format, outputPath s
 	return b.WriteDir(ctx, outputPath)
 }
 
-func assembleSparseLayout(ctx context.Context, manifestPath, configPath, outputPath, format string, layers, layerCompactStreamFlags layerMappingFlag) error {
+func assembleSparseLayout(ctx context.Context, manifestPath, configPath, outputPath, format string, layers, layerCompactStreamFlags layerMappingFlag, useSymlinks bool) error {
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return fmt.Errorf("reading manifest: %w", err)
@@ -186,11 +188,12 @@ func assembleSparseLayout(ctx context.Context, manifestPath, configPath, outputP
 	}
 
 	b := ocilayout.New(ocilayout.SparseOCILayout()).
+		WithLinkStrategy(useSymlinks, false).
 		AddManifest(sparseManifestInput(&manifest, manifestData, configPath, metaByDigest, cstreamByDigest))
 	return writeLayout(ctx, b, format, outputPath)
 }
 
-func assembleSparseLayoutWithIndex(ctx context.Context, indexPath, outputPath, format string, manifestPaths, configPaths []string, layers, layerCompactStreamFlags layerMappingFlag) error {
+func assembleSparseLayoutWithIndex(ctx context.Context, indexPath, outputPath, format string, manifestPaths, configPaths []string, layers, layerCompactStreamFlags layerMappingFlag, useSymlinks bool) error {
 	indexData, err := os.ReadFile(indexPath)
 	if err != nil {
 		return fmt.Errorf("reading index: %w", err)
@@ -206,6 +209,7 @@ func assembleSparseLayoutWithIndex(ctx context.Context, indexPath, outputPath, f
 	}
 
 	b := ocilayout.New(ocilayout.SparseOCILayout()).
+		WithLinkStrategy(useSymlinks, false).
 		SetRootIndex(ocilayout.BlobFromBytes(indexData))
 
 	for i := range manifestPaths {

--- a/img_tool/pkg/ocilayout/builder_test.go
+++ b/img_tool/pkg/ocilayout/builder_test.go
@@ -356,6 +356,52 @@ func TestSparseLayout(t *testing.T) {
 	}
 }
 
+// A sparse layout carries the config and each layer's compact stream as file
+// blobs, so both are symlinked under the link strategy; the generated layer
+// descriptors are always written out.
+func TestSparseLayoutSymlinks(t *testing.T) {
+	manifest, manifestData, _, configHex, layerHex := makeTestManifest()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config")
+	os.WriteFile(configPath, []byte(`{"architecture":"amd64","os":"linux"}`), 0o644)
+	cstreamPath := filepath.Join(dir, "layer.cstream")
+	os.WriteFile(cstreamPath, []byte("fake compact stream"), 0o644)
+	out := filepath.Join(dir, "sparse")
+
+	cstream := BlobFromPath(cstreamPath)
+	mi := ManifestInput{Manifest: manifest, ManifestData: manifestData, Config: BlobFromPath(configPath)}
+	mi.Layers = []LayerInput{{Descriptor: manifest.Layers[0], CompactStream: &cstream}}
+
+	if err := New(SparseOCILayout()).WithLinkStrategy(true, false).AddManifest(mi).WriteDir(context.Background(), out); err != nil {
+		t.Fatalf("WriteDir: %v", err)
+	}
+
+	for source, linkPath := range map[string]string{
+		configPath:  filepath.Join(out, "blobs/sha256", configHex),
+		cstreamPath: filepath.Join(out, "blobs/sha256", layerHex+".cstream"),
+	} {
+		target, err := os.Readlink(linkPath)
+		if err != nil {
+			t.Fatalf("reading symlink %s: %v", linkPath, err)
+		}
+		if filepath.IsAbs(target) {
+			t.Errorf("symlink target must be relative, got %q", target)
+		}
+		if resolved := filepath.Join(filepath.Dir(linkPath), target); resolved != source {
+			t.Errorf("resolved symlink: got %q want %q", resolved, source)
+		}
+	}
+
+	descriptor := filepath.Join(out, "blobs/sha256", layerHex+".descriptor.json")
+	info, err := os.Lstat(descriptor)
+	if err != nil {
+		t.Fatalf("stat %s: %v", descriptor, err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Errorf("layer descriptor mode: got %v, want a regular file", info.Mode())
+	}
+}
+
 func TestMissingBlobs(t *testing.T) {
 	manifest, manifestData, _, _, _ := makeTestManifest()
 	dir := t.TempDir()


### PR DESCRIPTION
The sparse OCI layout and the content-addressed input directory (`.inputfilecas`) of a compact layer contain copies of files that Bazel has. Each image writes its config blobs, its compact streams and its layer input files a second time.

This change adds the `--symlink` flag to the `img sparse-oci-layout` command and to the `img cas-dir` command. The img tool then makes relative symbolic links to the input files. The rules set the flag only when these two conditions are true:

- the Bazel version is 7.1 or later
- the exec platform is not Windows

The new `use_tree_symlinks` function contains these two conditions. The four callers use this one function.

Bazel keeps the symbolic links in a tree artifact when it writes the tree artifact to the cache and reads it again. These tree artifacts do not contain the content of the files. A tool that cannot read a symbolic link in the local execroot must get the blob from the action that makes the blob. Examples are:

- a `PushImage` action on a remote executor
- runfiles with the `--remote_download_minimal` flag
- the bes syncer, which reads compact stream data from the remote CAS