### PR TITLE
feat(gateway): write the log to a file

### DIFF
--- a/img_tool/cmd/oci-distribution-gateway/README.md
+++ b/img_tool/cmd/oci-distribution-gateway/README.md
@@ -9,7 +9,7 @@ therefore need no registry credentials of their own.
 See [Authenticating Build Actions](../../../docs/authenticating-build-actions.md#3-oci-distribution-gateway)
 for how build actions are pointed at a gateway. **This README documents running it
 as a service**: its modes, flags, policy file, client authentication, deployment,
-and metrics. One feature has a document of its own — the
+logging, and metrics. One feature has a document of its own — the
 [blob existence cache](blob-existence-cache.md), which is also where replicating it
 between the instances of a serving deployment is described.
 
@@ -110,6 +110,7 @@ gateway would have allowed.
 | `--unix-socket-mode <octal>` | (as created) | `chmod` the socket after binding, e.g. `0660` |
 | `--address <host>`, `--port <n>` | `localhost`, `0` | TCP alternative to `--unix-socket` |
 | `--shutdown-timeout <dur>` | `30s` | How long in-flight transfers may take to finish after a shutdown signal |
+| `--log-file <path>` | stderr | Append the log to this file instead of writing it to stderr. See [Logging](#logging) |
 | `--metrics-*` | off | See [Metrics](#metrics) |
 
 Reloadable material — the policy file, TLS keypairs, CA bundles and token files —
@@ -715,6 +716,43 @@ Kubernetes restartable init sidecar with a startup probe through the chart's
 `extraInitContainers` value. A separate Deployment or DaemonSet would require
 different network or volume plumbing and would expose the unauthenticated
 gateway beyond this private per-Pod socket.
+
+## Logging
+
+The gateway writes its log to stderr. The log contains one line for each request,
+the startup banner, the result of each reload, and all warnings.
+
+To write the log to a file, use `--log-file`:
+
+```bash
+oci-distribution-gateway forward --unix-socket /run/gw.sock \
+  --peer https://oci-gateway.img-gateway.svc:8443 --peer-token-file /var/run/gw/token \
+  --log-file /var/log/rules-img/gateway.log
+```
+
+The gateway makes the file if it does not exist. If the file exists, the gateway
+adds the new lines at the end of it.
+
+Errors in the command line stay on stderr. If the gateway cannot open the log
+file, it writes the error to stderr and stops.
+
+**Rotation.** When the gateway receives `SIGHUP`, it opens the log file again. To
+rotate the log, move the file, then send `SIGHUP` to the gateway. If the gateway
+cannot open the file again, it continues to write to the file it has open.
+
+This `logrotate` configuration does the two steps:
+
+```
+/var/log/rules-img/gateway.log {
+    daily
+    rotate 7
+    compress
+    missingok
+    postrotate
+        kill -HUP $(cat /run/rules-img-gateway.pid)
+    endscript
+}
+```
 
 ## Metrics
 

--- a/img_tool/cmd/oci-distribution-gateway/forward.go
+++ b/img_tool/cmd/oci-distribution-gateway/forward.go
@@ -44,6 +44,7 @@ type forwardFlags struct {
 	allowUnauthenticatedText bool
 
 	shutdownTimeout time.Duration
+	log             logFlags
 	metrics         metricsFlags
 }
 
@@ -67,6 +68,7 @@ func (f *forwardFlags) register(flagSet *flag.FlagSet) {
 	flagSet.BoolVar(&f.allowUnauthenticatedText, "dangerously-allow-unauthenticated-clients", false, "Serve a network-reachable address. DANGEROUS: a forwarder authenticates none of its own clients, so anything able to reach it can spend the peer's credential within the peer's policy.")
 
 	flagSet.DurationVar(&f.shutdownTimeout, "shutdown-timeout", 30*time.Second, "How long in-flight requests may take to finish after a shutdown signal. Set this above your longest blob transfer.")
+	f.log.register(flagSet)
 	f.metrics.register(flagSet)
 }
 
@@ -112,6 +114,11 @@ func forwardProcess(ctx context.Context, args []string) {
 		fmt.Fprintln(os.Stderr, "--dangerously-allow-unauthenticated-clients if the address really is private.")
 		os.Exit(1)
 	}
+
+	// From here on the forwarder is starting up rather than reading its command
+	// line, so everything it reports goes wherever --log-file points.
+	logging := flags.log.setup()
+	defer logging.close()
 
 	metrics, metricsServer, flush := flags.metrics.setup(ctx, forwardServiceName)
 	defer flush()
@@ -184,6 +191,7 @@ func forwardProcess(ctx context.Context, args []string) {
 	signal.Notify(hup, syscall.SIGHUP)
 	go func() {
 		for range hup {
+			logging.reopen()
 			if err := peerTLS.Reload(); err != nil {
 				log.Printf("peer TLS material reload FAILED, keeping previous material: %v", err)
 				continue

--- a/img_tool/cmd/oci-distribution-gateway/helpers_test.go
+++ b/img_tool/cmd/oci-distribution-gateway/helpers_test.go
@@ -99,3 +99,12 @@ type testTCPAddr struct {
 func (a *testTCPAddr) addr() net.Addr {
 	return &net.TCPAddr{IP: net.ParseIP(a.ip), Port: a.port}
 }
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(contents)
+}

--- a/img_tool/cmd/oci-distribution-gateway/main.go
+++ b/img_tool/cmd/oci-distribution-gateway/main.go
@@ -265,7 +265,12 @@ func (s *logSink) open() error {
 	s.file = file
 	log.SetOutput(file)
 	if previous != nil {
-		previous.Close()
+		// Reported rather than dropped: close is where a write the kernel deferred
+		// finally fails, so a rotation onto a full disk says so here or nowhere. The
+		// new file is already the destination, so this line lands in it.
+		if err := previous.Close(); err != nil {
+			log.Printf("closing the previous --log-file %q failed, some lines may be missing from it: %v", s.path, err)
+		}
 	}
 	return nil
 }
@@ -286,7 +291,9 @@ func (s *logSink) reopen() {
 }
 
 // close returns logging to stderr and closes the file, so a line written while
-// the process is on its way out does not go to a closed descriptor.
+// the process is on its way out does not go to a closed descriptor. A close that
+// fails is reported on stderr, which logging has just gone back to: the file it
+// would otherwise be written to is the one that could not be closed.
 func (s *logSink) close() {
 	if s == nil {
 		return
@@ -297,7 +304,9 @@ func (s *logSink) close() {
 		return
 	}
 	log.SetOutput(os.Stderr)
-	s.file.Close()
+	if err := s.file.Close(); err != nil {
+		log.Printf("closing --log-file %q failed, the last lines may be missing from it: %v", s.path, err)
+	}
 	s.file = nil
 }
 

--- a/img_tool/cmd/oci-distribution-gateway/main.go
+++ b/img_tool/cmd/oci-distribution-gateway/main.go
@@ -38,6 +38,10 @@
 // A bare invocation with no subcommand means serving mode, so existing
 // deployments keep working unchanged.
 //
+// The decision the gateway took on every request, along with its reloads and
+// warnings, is logged to stderr, or to the file named by --log-file for a
+// gateway sharing its output with something else.
+//
 // Traffic, blob transfers, and errors are reported as OpenTelemetry metrics,
 // either pushed to a collector over OTLP or scraped from a Prometheus endpoint;
 // see --metrics-exporter and //pkg/serve/telemetry.
@@ -56,6 +60,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -206,6 +211,96 @@ func printUsage(flagSet *flag.FlagSet, description, usageLine string, examples [
 	}
 }
 
+// logFlags holds the logging flag both modes accept.
+type logFlags struct {
+	file string
+}
+
+func (f *logFlags) register(flagSet *flag.FlagSet) {
+	flagSet.StringVar(&f.file, "log-file", "", "Append the gateway's log to this file instead of writing it to stderr. Everything the running gateway reports goes there: the decision it took on every request, reload results, warnings, and the startup banner. Created if it does not exist, and reopened on SIGHUP, which is what a log rotator needs after moving it aside.")
+}
+
+// setup points the gateway's logging at --log-file, or leaves it on stderr when
+// the flag is unset. It must be called before anything is logged, and the
+// returned sink must be closed by the caller (and reopened on SIGHUP).
+//
+// One redirection moves every line the process writes, because every part of it
+// logs through the standard logger: the handler's decision log, the forwarder,
+// client authentication, TLS and token reloads, peer discovery, and cache
+// replication. What stays on stderr is the errors that reject the command line
+// itself, which are reported before this is called — a misconfigured gateway
+// still says so where it was started, rather than in a file it may not have been
+// able to create.
+func (f *logFlags) setup() *logSink {
+	if f.file == "" {
+		return nil
+	}
+	sink := &logSink{path: f.file}
+	if err := sink.open(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	return sink
+}
+
+// logSink is the open --log-file. A nil sink is a gateway logging to stderr, so
+// every method has to tolerate one.
+type logSink struct {
+	path string
+
+	mu   sync.Mutex
+	file *os.File
+}
+
+// open opens the log file and makes it the destination of the standard logger,
+// closing whatever this sink had open before.
+func (s *logSink) open() error {
+	file, err := os.OpenFile(s.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening --log-file %q: %w", s.path, err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previous := s.file
+	s.file = file
+	log.SetOutput(file)
+	if previous != nil {
+		previous.Close()
+	}
+	return nil
+}
+
+// reopen re-opens the log file, which is how a rotated log keeps being written:
+// once the rotator has renamed the file, the gateway holds a descriptor to
+// something no one can find any more until the path is opened again.
+//
+// A failure keeps the descriptor already open, so a rotation that goes wrong
+// costs no log lines — the same rule the policy and TLS reloads follow.
+func (s *logSink) reopen() {
+	if s == nil {
+		return
+	}
+	if err := s.open(); err != nil {
+		log.Printf("log file reopen FAILED, keeping the open one: %v", err)
+	}
+}
+
+// close returns logging to stderr and closes the file, so a line written while
+// the process is on its way out does not go to a closed descriptor.
+func (s *logSink) close() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file == nil {
+		return
+	}
+	log.SetOutput(os.Stderr)
+	s.file.Close()
+	s.file = nil
+}
+
 // metricsFlags holds the OpenTelemetry flags both modes accept, so the two flag
 // sets and the Prometheus listener are declared in exactly one place.
 type metricsFlags struct {
@@ -279,7 +374,7 @@ func (f *metricsFlags) setup(ctx context.Context, serviceName string) (*telemetr
 			log.Printf("metrics endpoint error: %v", err)
 		}
 	}()
-	fmt.Fprintf(os.Stderr, "oci-distribution-gateway serving metrics on %s/metrics\n", metricsListener.Addr())
+	log.Printf("serving metrics on %s/metrics", metricsListener.Addr())
 	return metrics, metricsServer, flush
 }
 
@@ -321,10 +416,10 @@ func (g *gatewayServer) run() {
 	serveErr := make(chan error, 2)
 	go func() { serveErr <- g.serve() }()
 
-	fmt.Fprintf(os.Stderr, "%s on %s\n", g.banner, g.addr)
+	log.Printf("%s on %s", g.banner, g.addr)
 	if g.peer != nil {
 		go func() { serveErr <- g.peer.serve() }()
-		fmt.Fprintf(os.Stderr, "%s for cache replication peers on %s\n", g.banner, g.peer.addr)
+		log.Printf("%s for cache replication peers on %s", g.banner, g.peer.addr)
 	}
 
 	select {

--- a/img_tool/cmd/oci-distribution-gateway/main_test.go
+++ b/img_tool/cmd/oci-distribution-gateway/main_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -583,14 +584,36 @@ func TestLogFileCapturesEverythingTheGatewayLogs(t *testing.T) {
 		t.Errorf("log file = %q, want the earlier run appended to, not truncated", got)
 	}
 
-	// Rotation: the rotator renames the file away, and until the gateway opens the
-	// path again it is writing to something nobody can find.
+	// A reopen with the file still where it was appends to it, rather than
+	// truncating what is already there.
+	sink.reopen()
+	log.Print("after the reopen")
+	if got := readFile(t, path); !strings.Contains(got, "a decision") || !strings.Contains(got, "after the reopen") {
+		t.Errorf("log file after reopen = %q, want it appended to, not truncated", got)
+	}
+}
+
+func TestLogFileReopensAfterRotation(t *testing.T) {
+	// Renaming a file a process holds open is a POSIX move, and it is the one a
+	// log rotator makes. Windows refuses it outright, and never delivers the
+	// SIGHUP that would trigger the reopen either.
+	if runtime.GOOS == "windows" {
+		t.Skip("a rotator cannot rename a file the gateway holds open on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "gateway.log")
+	sink := (&logFlags{file: path}).setup()
+	t.Cleanup(sink.close)
+
+	// The rotator renames the file away, and until the gateway opens the path
+	// again it is writing to something nobody can find.
 	rotated := path + ".1"
+	log.Print("before the rotation")
 	if err := os.Rename(path, rotated); err != nil {
 		t.Fatalf("rotating the log file: %v", err)
 	}
 	sink.reopen()
 	log.Print("after the rotation")
+
 	if got := readFile(t, path); !strings.Contains(got, "after the rotation") {
 		t.Errorf("log file after reopen = %q, want the line logged after the rotation", got)
 	}

--- a/img_tool/cmd/oci-distribution-gateway/main_test.go
+++ b/img_tool/cmd/oci-distribution-gateway/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -563,4 +564,48 @@ func TestRejectSelfPeer(t *testing.T) {
 			t.Errorf("rejectSelfPeer(%s) = %v, want error: %v", tc.peer, err, tc.wantErr)
 		}
 	}
+}
+
+func TestLogFileCapturesEverythingTheGatewayLogs(t *testing.T) {
+	// The point of the flag: a sidecar's log goes to a file of its own instead of
+	// into the output of whatever it shares a terminal with. Every part of the
+	// gateway logs through the standard logger, so this one redirection is the
+	// whole mechanism.
+	path := filepath.Join(t.TempDir(), "gateway.log")
+	if err := os.WriteFile(path, []byte("an earlier run\n"), 0o600); err != nil {
+		t.Fatalf("seeding the log file: %v", err)
+	}
+	sink := (&logFlags{file: path}).setup()
+	t.Cleanup(sink.close)
+
+	log.Print("a decision")
+	if got := readFile(t, path); !strings.Contains(got, "an earlier run") || !strings.Contains(got, "a decision") {
+		t.Errorf("log file = %q, want the earlier run appended to, not truncated", got)
+	}
+
+	// Rotation: the rotator renames the file away, and until the gateway opens the
+	// path again it is writing to something nobody can find.
+	rotated := path + ".1"
+	if err := os.Rename(path, rotated); err != nil {
+		t.Fatalf("rotating the log file: %v", err)
+	}
+	sink.reopen()
+	log.Print("after the rotation")
+	if got := readFile(t, path); !strings.Contains(got, "after the rotation") {
+		t.Errorf("log file after reopen = %q, want the line logged after the rotation", got)
+	}
+	if got := readFile(t, rotated); strings.Contains(got, "after the rotation") {
+		t.Errorf("rotated file = %q, want nothing written to it after the reopen", got)
+	}
+}
+
+func TestLogFileUnsetLeavesLoggingOnStderr(t *testing.T) {
+	// The default has to stay exactly what it was: no file, no redirection, and a
+	// nil sink that the deferred close and the SIGHUP reopen both tolerate.
+	sink := (&logFlags{}).setup()
+	if sink != nil {
+		t.Fatalf("setup with no --log-file returned %v, want nil", sink)
+	}
+	sink.reopen()
+	sink.close()
 }

--- a/img_tool/cmd/oci-distribution-gateway/serve.go
+++ b/img_tool/cmd/oci-distribution-gateway/serve.go
@@ -69,6 +69,7 @@ type serveFlags struct {
 	peerClientCAFile                 string
 	allowUnauthenticatedPeerListener bool
 
+	log     logFlags
 	metrics metricsFlags
 }
 
@@ -133,6 +134,7 @@ func (f *serveFlags) register(flagSet *flag.FlagSet) {
 	flagSet.StringVar(&f.peerClientCAFile, "peer-client-ca-file", "", "PEM bundle of CAs whose client certificates the peer listener accepts. Setting it enables mTLS there and requires a certificate for that listener. Defaults to --client-ca-file. This is the flag that lets instances speak mTLS to each other while clients do not.")
 	flagSet.BoolVar(&f.allowUnauthenticatedPeerListener, "dangerously-allow-unauthenticated-peer-listener", false, "Run the peer listener with no client authentication. DANGEROUS: anything able to reach it can insert blob existence facts, and a client that believes a false one skips an upload it still owes.")
 
+	f.log.register(flagSet)
 	f.metrics.register(flagSet)
 }
 
@@ -201,6 +203,11 @@ func serveProcess(ctx context.Context, args []string) {
 			flags.blobCacheMaxMemory, gateway.MinBlobExistenceCacheBytes)
 		os.Exit(1)
 	}
+
+	// From here on the gateway is starting up rather than reading its command
+	// line, so everything it reports goes wherever --log-file points.
+	logging := flags.log.setup()
+	defer logging.close()
 
 	// Resolve the authorization policy. --dangerously-allow-all overrides (and
 	// ignores) any policy file; otherwise a policy file is required.
@@ -402,6 +409,7 @@ func serveProcess(ctx context.Context, args []string) {
 	signal.Notify(hup, syscall.SIGHUP)
 	go func() {
 		for range hup {
+			logging.reopen()
 			if flags.policyFile != "" && !flags.dangerouslyAllowAll {
 				if cp, err := handler.Reload(flags.policyFile); err != nil {
 					log.Printf("policy reload FAILED, keeping previous policy: %v", err)

--- a/img_tool/pkg/serve/gateway/BUILD.bazel
+++ b/img_tool/pkg/serve/gateway/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "gateway_test.go",
         "h2_test.go",
         "hardening_test.go",
+        "logger_test.go",
         "memconn_test.go",
         "metrics_test.go",
         "peerauth_resumption_test.go",

--- a/img_tool/pkg/serve/gateway/forward.go
+++ b/img_tool/pkg/serve/gateway/forward.go
@@ -103,7 +103,7 @@ func NewForward(cfg ForwardConfig) (*ForwardHandler, error) {
 		log:         cfg.Logger,
 	}
 	if f.log == nil {
-		f.log = log.New(os.Stderr, "", log.LstdFlags)
+		f.log = log.Default()
 	}
 	if f.forwarderID == "" {
 		f.forwarderID, _ = os.Hostname()

--- a/img_tool/pkg/serve/gateway/gateway.go
+++ b/img_tool/pkg/serve/gateway/gateway.go
@@ -34,7 +34,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -222,7 +221,7 @@ func New(opts ...Option) *Handler {
 	h := &Handler{
 		keychain: authn.DefaultKeychain,
 		base:     defaultBaseTransport(),
-		log:      log.New(os.Stderr, "", log.LstdFlags),
+		log:      log.Default(),
 		now:      time.Now,
 	}
 	for _, o := range opts {

--- a/img_tool/pkg/serve/gateway/logger_test.go
+++ b/img_tool/pkg/serve/gateway/logger_test.go
@@ -1,0 +1,72 @@
+package gateway
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+)
+
+// TestComponentsDefaultToTheStandardLogger pins the invariant the gateway's
+// --log-file rests on: a component given no Logger of its own logs through
+// [log.Default], so one [log.SetOutput] moves everything the process writes into
+// the file. A component that built itself a logger on os.Stderr instead would
+// keep writing to the console, and nothing would say so.
+func TestComponentsDefaultToTheStandardLogger(t *testing.T) {
+	// Constructing these logs a line or two, which is the very thing being
+	// asserted: redirecting the standard logger takes it out of the test output.
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	peerURL, err := url.Parse("https://gateway.test:8443")
+	if err != nil {
+		t.Fatalf("parsing the peer URL: %v", err)
+	}
+	forward, err := NewForward(ForwardConfig{Peer: peerURL})
+	if err != nil {
+		t.Fatalf("NewForward: %v", err)
+	}
+	peerAuth, err := NewPeerAuth(PeerAuthOptions{TokenFiles: []string{writeTokens(t, testToken)}})
+	if err != nil {
+		t.Fatalf("NewPeerAuth: %v", err)
+	}
+	peerTLS, err := NewPeerTLS(PeerTLSOptions{})
+	if err != nil {
+		t.Fatalf("NewPeerTLS: %v", err)
+	}
+	peers, err := NewKubernetesPeers(KubernetesPeerOptions{
+		Service:      "img-gateway/oci-distribution-gateway",
+		Port:         8443,
+		SelfName:     "gateway-0",
+		APIServerURL: "https://api.test",
+		Client:       &http.Client{},
+	})
+	if err != nil {
+		t.Fatalf("NewKubernetesPeers: %v", err)
+	}
+	replication, err := NewCacheReplication(ReplicationConfig{
+		Peers:  StaticPeers{"https://peer.test:8443"},
+		SelfID: "gateway-0",
+	})
+	if err != nil {
+		t.Fatalf("NewCacheReplication: %v", err)
+	}
+
+	for _, tc := range []struct {
+		component string
+		logger    *log.Logger
+	}{
+		{"the serving handler", New().log},
+		{"the forwarder", forward.log},
+		{"client authentication", peerAuth.log},
+		{"TLS material", peerTLS.log},
+		{"peer discovery", peers.log},
+		{"cache replication", replication.log},
+	} {
+		if tc.logger != log.Default() {
+			t.Errorf("%s logs through a logger of its own, so --log-file would not capture it", tc.component)
+		}
+	}
+}

--- a/img_tool/pkg/serve/gateway/peerauth.go
+++ b/img_tool/pkg/serve/gateway/peerauth.go
@@ -163,7 +163,7 @@ type PeerAuth struct {
 func NewPeerAuth(opts PeerAuthOptions) (*PeerAuth, error) {
 	a := &PeerAuth{opts: opts, log: opts.Logger, stamps: make(map[string]fileStamp)}
 	if a.log == nil {
-		a.log = log.New(os.Stderr, "", log.LstdFlags)
+		a.log = log.Default()
 	}
 	for _, id := range opts.AllowedClientIDs {
 		pattern, err := compileIdentityPattern(id)

--- a/img_tool/pkg/serve/gateway/peers.go
+++ b/img_tool/pkg/serve/gateway/peers.go
@@ -154,7 +154,7 @@ func NewKubernetesPeers(opts KubernetesPeerOptions) (*KubernetesPeers, error) {
 		slices:    make(map[string][]Peer),
 	}
 	if k.log == nil {
-		k.log = log.New(os.Stderr, "", log.LstdFlags)
+		k.log = log.Default()
 	}
 	if k.scheme == "" {
 		k.scheme = "https"

--- a/img_tool/pkg/serve/gateway/peertls.go
+++ b/img_tool/pkg/serve/gateway/peertls.go
@@ -90,7 +90,7 @@ func NewPeerTLS(opts PeerTLSOptions) (*PeerTLS, error) {
 	}
 	t := &PeerTLS{opts: opts, log: opts.Logger, stamps: make(map[string]fileStamp)}
 	if t.log == nil {
-		t.log = log.New(os.Stderr, "", log.LstdFlags)
+		t.log = log.Default()
 	}
 	if err := t.loadCertificate(); err != nil {
 		return nil, err

--- a/img_tool/pkg/serve/gateway/replication.go
+++ b/img_tool/pkg/serve/gateway/replication.go
@@ -361,7 +361,7 @@ func NewCacheReplication(cfg ReplicationConfig) (*CacheReplication, error) {
 		donating:      make(chan struct{}, maxConcurrentDonations),
 	}
 	if r.log == nil {
-		r.log = log.New(os.Stderr, "", log.LstdFlags)
+		r.log = log.Default()
 	}
 	if r.batchSize <= 0 {
 		r.batchSize = defaultReplicationBatchSize


### PR DESCRIPTION
The oci-distribution-gateway writes its log to stderr. When the gateway shares its output with a different process, it is difficult to read the log.

The new `--log-file` flag writes the log to a file. The `serve` mode and the `forward` mode accept the flag. The gateway makes the file if the file does not exist. If the file exists, the gateway adds the new lines at the end of it. Errors in the command line stay on stderr.

Each part of the gateway made a logger on stderr. These parts now use the standard logger, which the flag sends to the file. This is the behavior that the `Logger` option of each part specifies.

The startup banners also use the standard logger. Before this change, the banners went directly to stderr.

When the gateway receives `SIGHUP`, it opens the log file again. To rotate the log, move the file, then send the signal. If the gateway cannot open the file again, it continues to write to the file it has open.