### PR TITLE
prepare 0.3.21

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_img",
-    version = "0.3.20",
+    version = "0.3.21",
 )
 
 bazel_dep(name = "bazel_features", version = "1.47.0")
@@ -46,7 +46,7 @@ bazel_dep(name = "gazelle", version = "0.53.0", dev_dependency = True)
 bazel_dep(name = "protobuf", version = "35.1", dev_dependency = True)
 bazel_dep(name = "rules_bazel_integration_test", version = "0.37.1", dev_dependency = True)
 bazel_dep(name = "rules_go", version = "0.63.0", dev_dependency = True)
-bazel_dep(name = "rules_img_tool", version = "0.3.20", dev_dependency = True)
+bazel_dep(name = "rules_img_tool", version = "0.3.21", dev_dependency = True)
 bazel_dep(name = "rules_pkg", version = "1.2.0", dev_dependency = True)
 bazel_dep(name = "rules_python", version = "2.1.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -420,7 +420,7 @@
     "@@rules_bazel_integration_test+//:extensions.bzl%bazel_binaries": {
       "general": {
         "bzlTransitiveDigest": "XC9nqZ31LIbq8N7cEK+rYa2iXNQLcJ3cyGWw+zPZlc0=",
-        "usagesDigest": "aDln9sS6YFdCn5RIVI8UeTGacrIjEvHbT9v4cdo6A90=",
+        "usagesDigest": "VL+UgYgo3MNu+5WHfdYKb5UPR7TjwKWICO1uPCNExtE=",
         "recordedInputs": [
           "REPO_MAPPING:rules_bazel_integration_test+,bazel_skylib bazel_skylib+",
           "REPO_MAPPING:rules_bazel_integration_test+,cgrindel_bazel_starlib cgrindel_bazel_starlib+"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Supports both **Bzlmod** and **WORKSPACE** setups. For WORKSPACE setup instructi
 Add to your `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "rules_img", version = "0.3.20")
+bazel_dep(name = "rules_img", version = "0.3.21")
 ```
 
 <details>

--- a/img_tool/MODULE.bazel
+++ b/img_tool/MODULE.bazel
@@ -1,9 +1,9 @@
 module(
     name = "rules_img_tool",
-    version = "0.3.20",
+    version = "0.3.21",
 )
 
-bazel_dep(name = "rules_img", version = "0.3.20")
+bazel_dep(name = "rules_img", version = "0.3.21")
 bazel_dep(name = "bazel_lib", version = "3.3.1")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "gazelle", version = "0.53.0")

--- a/modules/rules_img_internal_tools/MODULE.bazel
+++ b/modules/rules_img_internal_tools/MODULE.bazel
@@ -21,9 +21,9 @@ bazel_dep(name = "gazelle", version = "0.53.0")
 # direct dep here (not in the root) so the root depends on them only transitively
 # through this module, and so the signer CLIs / plugins can be re-exported and
 # prebuilt for the e2e tests.
-bazel_dep(name = "rules_img", version = "0.3.20")
+bazel_dep(name = "rules_img", version = "0.3.21")
 bazel_dep(name = "rules_img_private", version = "0.0.1")
-bazel_dep(name = "rules_img_tool", version = "0.3.20")
+bazel_dep(name = "rules_img_tool", version = "0.3.21")
 bazel_dep(name = "rules_img_signer_cosign", version = "0.0.1")
 bazel_dep(name = "rules_img_signer_notation", version = "0.0.1")
 

--- a/modules/rules_img_internal_tools/go.mod
+++ b/modules/rules_img_internal_tools/go.mod
@@ -3,7 +3,7 @@ module github.com/bazel-contrib/rules_img/modules/rules_img_internal_tools
 go 1.26.5
 
 require (
-	github.com/bazel-contrib/rules_img/img_tool v0.3.20
+	github.com/bazel-contrib/rules_img/img_tool v0.3.21
 	github.com/bazelbuild/bazel-gazelle v0.53.0
 	github.com/bazelbuild/buildtools v0.0.0-20260826221324-7cca172268c7
 	github.com/bazelbuild/rules_go v0.63.0

--- a/modules/rules_img_internal_tools/go.sum
+++ b/modules/rules_img_internal_tools/go.sum
@@ -1,7 +1,7 @@
 github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-3 h1:Mq3iQ30V39RGCErrbnhHFOAcnxpWTIrk35Pc9guNfOY=
 github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-3/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
-github.com/bazel-contrib/rules_img/img_tool v0.3.20 h1:gj9gHOOBsUJU9B8UPke035RNwVcREL/cKxUxYfSCgHs=
-github.com/bazel-contrib/rules_img/img_tool v0.3.20/go.mod h1:4kv3adKhEqVgEiGnQB4aOeWoQm3I9jQIMwhtIYJXWvY=
+github.com/bazel-contrib/rules_img/img_tool v0.3.21 h1:gj9gHOOBsUJU9B8UPke035RNwVcREL/cKxUxYfSCgHs=
+github.com/bazel-contrib/rules_img/img_tool v0.3.21/go.mod h1:4kv3adKhEqVgEiGnQB4aOeWoQm3I9jQIMwhtIYJXWvY=
 github.com/bazelbuild/bazel-gazelle v0.53.0 h1:qNh2WraxM8cjIeHZQ7QPTTSPbkrX9Z0GkhtGbiz1ToE=
 github.com/bazelbuild/bazel-gazelle v0.53.0/go.mod h1:ncMNvFUTYi5NRQ7wVrOmxjKaR0+mvm02lhBt7UOXlVc=
 github.com/bazelbuild/buildtools v0.0.0-20260826221324-7cca172268c7 h1:wMV4VxHlrWIgLL737mKv9kfEGf4ZRpwB6beBTzBM51w=

--- a/modules/rules_img_services/MODULE.bazel
+++ b/modules/rules_img_services/MODULE.bazel
@@ -2,11 +2,11 @@ module(name = "rules_img_services")
 
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_go", version = "0.63.0")
-bazel_dep(name = "rules_img", version = "0.3.20")
+bazel_dep(name = "rules_img", version = "0.3.21")
 bazel_dep(name = "rules_img_internal_tools", version = "0.0.1")
 bazel_dep(name = "rules_img_private", version = "0.0.1")
 bazel_dep(name = "rules_img_signer_cosign", version = "0.0.1")
-bazel_dep(name = "rules_img_tool", version = "0.3.20")
+bazel_dep(name = "rules_img_tool", version = "0.3.21")
 
 register_toolchains("@rules_img_tool//toolchain:all")
 


### PR DESCRIPTION
Prepare the 0.3.21 release by updating module versions, internal dependencies, and the README installation example, following the previous release's version-bump pattern. Regenerate MODULE.bazel.lock with `bazel query ...`.

Validation: `bazel query ...` succeeded and `git diff --check` passed. Bazel reported the existing platforms dependency version mismatch (requested 1.0.0, resolved 1.1.0).
