### PR TITLE
fix(prebuilt): mark the prebuilt img tool repo as reproducible

### DIFF
--- a/img/private/prebuilt/prebuilt.bzl
+++ b/img/private/prebuilt/prebuilt.bzl
@@ -121,6 +121,15 @@ def _prebuilt_img_tool_repo_impl(rctx):
         content = """exports_files(["img.exe"])""",
     )
 
+    if hasattr(rctx, "repo_metadata"):
+        # `fetch_tool` refuses to download without a digest to verify against,
+        # so the contents of this repo are a pure function of its attributes.
+        # Saying so allows participating in the repo contents cache.
+        return rctx.repo_metadata(reproducible = True)
+
+    # only to make buildifier happy
+    return None
+
 prebuilt_img_tool_repo = repository_rule(
     implementation = _prebuilt_img_tool_repo_impl,
     attrs = LOCKFILE_ATTRS,


### PR DESCRIPTION
The repository rule that downloads a prebuilt img binary never declared its contents reproducible, so every fetch of it went to the network again: one download per output base, and another one after every `bazel clean --expunge`, even though the same 25 MB binary was already sitting in a sibling workspace's external directory.

Its contents are a pure function of its attributes. `fetch_tool` refuses to download at all without a digest to verify the result against — a `url` mode entry needs `integrity` or `sha256`, and an `oci` mode entry addresses the blob by its digest — so the binary that lands in the repo is fully determined by the lockfile entry the repo was declared from. Saying so lets the repo participate in the repo contents cache, which is shared across output bases and survives an expunge. The repository rules that pull manifests and blobs already do this.

The declaration is guarded by a `hasattr` check, the way the pull repository rules guard theirs: `repo_metadata` does not exist on Bazel versions that predate the repo contents cache.

Fixes #746