### PR TITLE
Fix cross mount authorization issues

### DIFF
--- a/img_tool/cmd/deploymetadata/metadata.go
+++ b/img_tool/cmd/deploymetadata/metadata.go
@@ -739,11 +739,7 @@ func targetsIncludeReferrers(targets []string) bool {
 }
 
 func checkCrossMountSource(targetRegistry string, sourceRegistry string, sourceRepository string) *api.CrossMountSource {
-	if targetRegistry == sourceRegistry && (crossMountStrategy == "same_registry" || crossMountStrategy == "cross_registry") {
-		return &api.CrossMountSource{Repository: sourceRepository}
-	}
-
-	if crossMountStrategy == "cross_registry" {
+	if crossMountStrategy == "cross_registry" || (crossMountStrategy == "same_registry" && targetRegistry == sourceRegistry) {
 		return &api.CrossMountSource{Registry: sourceRegistry, Repository: sourceRepository}
 	}
 


### PR DESCRIPTION
After upgrading rules_img, I saw warnings in our CI.

```
mount=sha256%3A2bbd49ccc0c301eaeec3f42de2603ec8cb6d6ebf36e78c41aac93ddef6629033: UNAUTHORIZED: unauthorized to access repository: base/ubuntu24-jenkins, action: pull: unauthorized to access repository: base/ubuntu24-jenkins, action: pull
```

Turns out, the error was always there, but [this](https://github.com/bazel-contrib/rules_img/commit/c1b2bec9e8f4d8491bc6c551c371c3dfcbaa1c36#diff-c6a52abda8e2b079e61c103f016bf38a1edec86a6c79df8208a91fa5650490c9) commit enabled logging and it became visible.

In our case, cross mount is failing because we try to cross mount from `base/XXX` to `foo/YYY`. And go-containerregistry does some complicated logic with tokens, requesting token only for `foo:pull,push`. While our registry requires `base:pull` for cross mounting.

You recently added [hack](https://github.com/bazel-contrib/rules_img/commit/41be0a2287af058ecadf14db677dde414d03024c) that strips origin parameter from wire request.

That makes it so that we can pass Registry parameter. And that somehow makes go-containerregistry correctly update token scope. By skipping this [if](https://github.com/google/go-containerregistry/blob/main/pkg/v1/remote/write.go#L144-L146)